### PR TITLE
Rename project references to CDXBOT0310

### DIFF
--- a/CDXBOT0310.service
+++ b/CDXBOT0310.service
@@ -14,7 +14,7 @@ RestartSec=10
 # Логирование
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=commentbot
+SyslogIdentifier=CDXBOT0310
 
 # Безопасность
 NoNewPrivileges=true

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -42,7 +42,7 @@ API_ID=your_api_id
 API_HASH=your_api_hash
 OPENAI_API_KEY=your_openai_key
 PASSWORD=your_admin_password
-DATABASE_URL=sqlite:///data/commentbot.db
+DATABASE_URL=sqlite:///data/CDXBOT0310.db
 LOG_CHANNEL_ID=your_log_channel_id
 ```
 
@@ -125,7 +125,7 @@ docker-compose logs -f bot     # View bot logs
 ### Check bot status
 ```bash
 # Traditional
-sudo systemctl status commentbot
+sudo systemctl status CDXBOT0310
 
 # Docker
 docker-compose ps
@@ -134,7 +134,7 @@ docker-compose ps
 ### View logs
 ```bash
 # Traditional
-sudo journalctl -u commentbot -f
+sudo journalctl -u CDXBOT0310 -f
 
 # Docker
 docker-compose logs -f
@@ -143,10 +143,10 @@ docker-compose logs -f
 ### Check database
 ```bash
 # Traditional
-sqlite3 data/commentbot.db ".tables"
+sqlite3 data/CDXBOT0310.db ".tables"
 
 # Docker
-docker-compose exec bot sqlite3 data/commentbot.db ".tables"
+docker-compose exec bot sqlite3 data/CDXBOT0310.db ".tables"
 ```
 
 ## 🔒 Security Considerations
@@ -180,7 +180,7 @@ htop
 df -h
 
 # Database size
-du -h data/commentbot.db
+du -h data/CDXBOT0310.db
 ```
 
 ## 🔄 Updates and Maintenance
@@ -198,7 +198,7 @@ docker-compose up -d --build
 ### Backup data:
 ```bash
 # Backup database
-cp data/commentbot.db backups/commentbot_$(date +%Y%m%d).db
+cp data/CDXBOT0310.db backups/CDXBOT0310_$(date +%Y%m%d).db
 
 # Backup sessions
 tar -czf sessions_backup_$(date +%Y%m%d).tar.gz sessions/

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install -r requirements.txt
 
 ### 4. Настройка базы данных
 
-Бот использует файл базы данных SQLite. По умолчанию он создаётся автоматически в каталоге `data/commentbot.db`. Убедитесь, что у приложения есть права на запись в выбранную директорию или измените путь через переменную `DATABASE_URL`.
+Бот использует файл базы данных SQLite. По умолчанию он создаётся автоматически в каталоге `data/CDXBOT0310.db`. Убедитесь, что у приложения есть права на запись в выбранную директорию или измените путь через переменную `DATABASE_URL`.
 
 ### 5. Настройка переменных окружения
 
@@ -59,7 +59,7 @@ API_ID=your_api_id_here
 API_HASH=your_api_hash_here
 OPENAI_API_KEY=your_openai_api_key_here
 PASSWORD=your_secure_password_here
-DATABASE_URL=sqlite:///data/commentbot.db
+DATABASE_URL=sqlite:///data/CDXBOT0310.db
 
 # Настройки времени теперь в файле schedule.json
 # Отредактируйте schedule.json под ваши нужды
@@ -202,10 +202,10 @@ pip install -r requirements.txt
 
 3. **Настройка systemd сервиса**:
 ```bash
-sudo cp commentbot.service /etc/systemd/system/
+sudo cp CDXBOT0310.service /etc/systemd/system/
 sudo systemctl daemon-reload
-sudo systemctl enable commentbot
-sudo systemctl start commentbot
+sudo systemctl enable CDXBOT0310
+sudo systemctl start CDXBOT0310
 ```
 
 ### Управление ботом
@@ -220,11 +220,11 @@ sudo systemctl start commentbot
 ./manage.sh update     # Обновление
 
 # Или через systemd
-sudo systemctl start commentbot
-sudo systemctl stop commentbot
-sudo systemctl restart commentbot
-sudo systemctl status commentbot
-sudo journalctl -u commentbot -f
+sudo systemctl start CDXBOT0310
+sudo systemctl stop CDXBOT0310
+sudo systemctl restart CDXBOT0310
+sudo systemctl status CDXBOT0310
+sudo journalctl -u CDXBOT0310 -f
 ```
 
 📖 **Подробное руководство по развертыванию**: [DEPLOYMENT.md](DEPLOYMENT.md)
@@ -270,7 +270,7 @@ sudo journalctl -u commentbot -f
 
 ```bash
 # Просмотр логов systemd
-sudo journalctl -u commentbot -f
+sudo journalctl -u CDXBOT0310 -f
 
 # Просмотр логов Docker
 docker-compose logs -f

--- a/SERVER_UPDATE_INSTRUCTIONS.md
+++ b/SERVER_UPDATE_INSTRUCTIONS.md
@@ -50,7 +50,7 @@ sudo docker-compose logs bot --tail=20
 
 5. Проверьте в базе данных:
 ```bash
-sudo docker-compose exec bot sqlite3 data/commentbot.db "SELECT id, phone, sleep_min, sleep_max, chance FROM accounts WHERE phone = 'YOUR_PHONE';"
+sudo docker-compose exec bot sqlite3 data/CDXBOT0310.db "SELECT id, phone, sleep_min, sleep_max, chance FROM accounts WHERE phone = 'YOUR_PHONE';"
 ```
 
 Настройки должны быть сохранены (не NULL).

--- a/deploy.sh
+++ b/deploy.sh
@@ -90,7 +90,7 @@ log "Создаем директории для данных..."
 mkdir -p sessions logs data
 
 log "Настраиваем systemd сервис..."
-sudo tee /etc/systemd/system/commentbot.service > /dev/null <<EOF
+sudo tee /etc/systemd/system/CDXBOT0310.service > /dev/null <<EOF
 [Unit]
 Description=Telegram Comment Bot
 After=network.target
@@ -120,7 +120,7 @@ log "Перезагружаем systemd..."
 sudo systemctl daemon-reload
 
 log "Включаем автозапуск сервиса..."
-sudo systemctl enable commentbot
+sudo systemctl enable CDXBOT0310
 
 log "Создаем скрипт управления..."
 cat > manage.sh << 'EOF'
@@ -129,28 +129,28 @@ cat > manage.sh << 'EOF'
 case "$1" in
     start)
         echo "Запускаем бота..."
-        sudo systemctl start commentbot
+        sudo systemctl start CDXBOT0310
         ;;
     stop)
         echo "Останавливаем бота..."
-        sudo systemctl stop commentbot
+        sudo systemctl stop CDXBOT0310
         ;;
     restart)
         echo "Перезапускаем бота..."
-        sudo systemctl restart commentbot
+        sudo systemctl restart CDXBOT0310
         ;;
     status)
-        sudo systemctl status commentbot
+        sudo systemctl status CDXBOT0310
         ;;
     logs)
-        sudo journalctl -u commentbot -f
+        sudo journalctl -u CDXBOT0310 -f
         ;;
     update)
         echo "Обновляем код..."
         git pull
         source venv/bin/activate
         pip install -r requirements.txt
-        sudo systemctl restart commentbot
+        sudo systemctl restart CDXBOT0310
         ;;
     *)
         echo "Использование: $0 {start|stop|restart|status|logs|update}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ version: '3.8'
 services:
   bot:
     build: .
-    container_name: commentbot
+    container_name: CDXBOT0310
     environment:
-      - DATABASE_URL=sqlite:///data/commentbot.db
+      - DATABASE_URL=sqlite:///data/CDXBOT0310.db
     env_file:
       - .env
     volumes:

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ def load_env_file():
 env_vars = load_env_file()
 BOT_TOKEN = env_vars.get("BOT_TOKEN") or os.getenv("BOT_TOKEN")
 print(f"BOT_TOKEN loaded: {BOT_TOKEN}")
-#APcommentbot @AP_comment_bot
+#APCDXBOT0310 @AP_comment_bot
 log_channel = -1003123025616 # cloveend #-1002711973256 #-1002678984799
 
 API_ID = int(env_vars.get("API_ID") or os.getenv("API_ID"))

--- a/server_test_settings.py
+++ b/server_test_settings.py
@@ -10,7 +10,7 @@ import os
 # Добавляем текущую директорию в путь для импорта
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-os.environ.setdefault("DATABASE_URL", "sqlite:///commentbot.db")
+os.environ.setdefault("DATABASE_URL", "sqlite:///CDXBOT0310.db")
 
 from db import (
     close_db,

--- a/test_settings_save.py
+++ b/test_settings_save.py
@@ -10,7 +10,7 @@ import os
 # Добавляем текущую директорию в путь для импорта
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-os.environ.setdefault("DATABASE_URL", "sqlite:///commentbot.db")
+os.environ.setdefault("DATABASE_URL", "sqlite:///CDXBOT0310.db")
 
 from db import init_db, update_account_settings, get_account_by_id
 

--- a/test_settings_with_env.py
+++ b/test_settings_with_env.py
@@ -11,7 +11,7 @@ import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 # Устанавливаем переменные окружения
-os.environ["DATABASE_URL"] = "sqlite:///test_data/commentbot.db"
+os.environ["DATABASE_URL"] = "sqlite:///test_data/CDXBOT0310.db"
 os.environ["BOT_TOKEN"] = "8231470375:AAFcpq4Se_u1r8TdhzXTohjlFGI9jIUTbio"
 os.environ["API_ID"] = "20047744"
 os.environ["API_HASH"] = "09c81e1d266b98a8d82291abaa75bba7"


### PR DESCRIPTION
## Summary
- replace the remaining `commentbot` references with `CDXBOT0310` across configuration, scripts, and documentation
- rename the systemd service file to `CDXBOT0310.service` and update setup instructions accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb5bdd9d8833083dda3639c548e7f