### PR TITLE
Refine warmup scheduling and add tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -325,6 +325,16 @@ def _next_join_window_start(reference: datetime, settings: Optional[WarmupSettin
     settings = settings or get_current_warmup_settings()
     start_time = settings.window_start
     start = datetime.combine(reference.date(), start_time).replace(tzinfo=timezone.utc)
+
+    if settings.spans_midnight:
+        # Для окон через полночь следующий старт — сегодняшний вечер,
+        # если мы еще не достигли его, иначе +1 день
+        if reference.time() < settings.window_end and reference < start:
+            return start
+        if reference >= start:
+            return start + timedelta(days=1)
+        return start
+
     if start <= reference:
         start = datetime.combine(
             reference.date() + timedelta(days=1),
@@ -333,21 +343,64 @@ def _next_join_window_start(reference: datetime, settings: Optional[WarmupSettin
     return start
 
 
-def _get_next_warmup_join(now: datetime, settings: Optional[WarmupSettingsData] = None) -> datetime:
+def _warmup_window_duration(settings: WarmupSettingsData) -> timedelta:
+    start_dt = datetime.combine(datetime.now(timezone.utc).date(), settings.window_start)
+    end_dt = datetime.combine(datetime.now(timezone.utc).date(), settings.window_end)
+    duration = end_dt - start_dt
+    if duration <= timedelta(0):
+        duration += timedelta(days=1)
+    return duration
+
+
+def _resolve_window_start(reference: datetime, settings: WarmupSettingsData) -> datetime:
+    start_time = settings.window_start
+    base_start = datetime.combine(reference.date(), start_time).replace(tzinfo=timezone.utc)
+
+    if settings.spans_midnight:
+        if reference.time() < settings.window_end:
+            return base_start - timedelta(days=1)
+        if reference >= base_start:
+            return base_start
+        return base_start
+
+    end_dt = datetime.combine(reference.date(), settings.window_end).replace(tzinfo=timezone.utc)
+    if reference < base_start:
+        return base_start
+    if reference >= end_dt:
+        return base_start + timedelta(days=1)
+    return base_start
+
+
+def plan_next_warmup_join(earliest: datetime, settings: Optional[WarmupSettingsData] = None) -> datetime:
     settings = settings or get_current_warmup_settings()
-    candidate = now + timedelta(seconds=_get_human_delay_seconds(settings))
-    if is_warmup_join_period(candidate):
-        return candidate
+    if earliest.tzinfo is None:
+        current = earliest.replace(tzinfo=timezone.utc)
+    else:
+        current = earliest.astimezone(timezone.utc)
 
-    window_start = _next_join_window_start(now, settings)
-    end_time = settings.window_end
-    window_end = datetime.combine(window_start.date(), end_time).replace(tzinfo=timezone.utc)
-    if settings.spans_midnight and window_end <= window_start:
-        window_end += timedelta(days=1)
+    window_duration = _warmup_window_duration(settings)
 
-    available_seconds = max(int((window_end - window_start).total_seconds()), 60)
-    jitter = random.randint(0, available_seconds - 1)
-    return window_start + timedelta(seconds=jitter)
+    while True:
+        window_start = _resolve_window_start(current, settings)
+        window_end = window_start + window_duration
+
+        if current < window_start:
+            current = window_start
+        elif current >= window_end:
+            current = window_start + timedelta(days=1)
+            continue
+
+        delay_seconds = _get_human_delay_seconds(settings)
+        candidate = current + timedelta(seconds=delay_seconds)
+
+        if candidate < window_end:
+            return candidate
+
+        current = window_start + timedelta(days=1)
+
+
+def _get_next_warmup_join(now: datetime, settings: Optional[WarmupSettingsData] = None) -> datetime:
+    return plan_next_warmup_join(now, settings)
 
 
 def is_quiet_period(now: datetime | None = None) -> bool:
@@ -1582,8 +1635,15 @@ async def process_warmup_accounts():
 
                 if joined_today >= daily_limit:
                     await bot.send_message(log_channel, f"Warmup: Account {session_key} reached daily limit, skipping")
-                    next_time = _get_next_warmup_join(_next_join_window_start(now, current_settings), current_settings)
+                    next_window_start = _next_join_window_start(now, current_settings)
+                    next_time = plan_next_warmup_join(next_window_start, current_settings)
                     await db_update_warmup_schedule(account["id"], next_join=next_time)
+                    logging.info(
+                        "Warmup schedule: account %s (%s) next join at %s",
+                        account["id"],
+                        session_key,
+                        next_time.isoformat(),
+                    )
                     account["warmup_next_join_at"] = next_time
                     continue
 
@@ -1595,6 +1655,12 @@ async def process_warmup_accounts():
                     await bot.send_message(log_channel, f"Warmup: Account {session_key} no pending channels, skipping")
                     next_time = _get_next_warmup_join(now, current_settings)
                     await db_update_warmup_schedule(account["id"], next_join=next_time)
+                    logging.info(
+                        "Warmup schedule: account %s (%s) next join at %s",
+                        account["id"],
+                        session_key,
+                        next_time.isoformat(),
+                    )
                     account["warmup_next_join_at"] = next_time
                     continue
 
@@ -1620,6 +1686,12 @@ async def process_warmup_accounts():
                 post_join_now = datetime.now(timezone.utc)
                 next_time = _get_next_warmup_join(post_join_now, current_settings)
                 await db_update_warmup_schedule(account["id"], next_join=next_time)
+                logging.info(
+                    "Warmup schedule: account %s (%s) next join at %s",
+                    account["id"],
+                    session_key,
+                    next_time.isoformat(),
+                )
                 account["warmup_next_join_at"] = next_time
 
         except Exception as e:
@@ -1791,6 +1863,12 @@ async def add_warmup_channels(message: Message, state: FSMContext) -> None:
             now = datetime.now(timezone.utc)
             tomorrow_4_30am = now.replace(hour=4, minute=30, second=0, microsecond=0) + timedelta(days=1)
             await db_update_warmup_schedule(account_id, next_join=tomorrow_4_30am)
+            logging.info(
+                "Warmup schedule: account %s (%s) next join at %s",
+                account_id,
+                session,
+                tomorrow_4_30am.isoformat(),
+            )
             
             # Запускаем аккаунт в режиме прогрева (С комментированием + прогрев)
             key = make_session_key(message.from_user.id, session)
@@ -1854,7 +1932,13 @@ async def add_warmup_channels(message: Message, state: FSMContext) -> None:
             now = datetime.now(timezone.utc)
             tomorrow_4_30am = now.replace(hour=4, minute=30, second=0, microsecond=0) + timedelta(days=1)
             await db_update_warmup_schedule(account_id, next_join=tomorrow_4_30am)
-            
+            logging.info(
+                "Warmup schedule: account %s (%s) next join at %s",
+                account_id,
+                session,
+                tomorrow_4_30am.isoformat(),
+            )
+
             # Запускаем аккаунт в режиме прогрева (С комментированием + прогрев)
             key = make_session_key(message.from_user.id, session)
             active_sessions[key] = True  # Устанавливаем для комментирования
@@ -1906,6 +1990,12 @@ async def add_warmup_channels(message: Message, state: FSMContext) -> None:
         now = datetime.now(timezone.utc)
         tomorrow_4_30am = now.replace(hour=4, minute=30, second=0, microsecond=0) + timedelta(days=1)
         await db_update_warmup_schedule(account_id, next_join=tomorrow_4_30am)
+        logging.info(
+            "Warmup schedule: account %s (%s) next join at %s",
+            account_id,
+            session,
+            tomorrow_4_30am.isoformat(),
+        )
     except Exception as e:
         await bot.send_message(log_channel, f"Ошибка при сохранении каналов прогрева для {session}: {e}")
         await bot.send_message(message.from_user.id, f"Ошибка при сохранении каналов прогрева: {e}")

--- a/test_warmup_schedule.py
+++ b/test_warmup_schedule.py
@@ -1,0 +1,231 @@
+import asyncio
+import importlib
+import os
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+
+
+def _ensure_stubbed_dependencies():
+    os.environ.setdefault("API_ID", "1")
+    os.environ.setdefault("API_HASH", "dummy")
+    os.environ.setdefault("BOT_TOKEN", "dummy")
+
+    if "pyrogram" not in sys.modules:
+        pyrogram = types.ModuleType("pyrogram")
+
+        class DummyClient:  # pragma: no cover - helpers for import only
+            def __init__(self, *args, **kwargs):
+                pass
+
+        pyrogram.Client = DummyClient
+        pyrogram.filters = types.SimpleNamespace()
+        sys.modules["pyrogram"] = pyrogram
+
+        errors = types.ModuleType("pyrogram.errors")
+
+        class DummyUserAlreadyParticipant(Exception):
+            pass
+
+        errors.UserAlreadyParticipant = DummyUserAlreadyParticipant
+        sys.modules["pyrogram.errors"] = errors
+
+    if "dotenv" not in sys.modules:
+        dotenv = types.ModuleType("dotenv")
+
+        def _noop(*args, **kwargs):
+            return None
+
+        dotenv.load_dotenv = _noop
+        sys.modules["dotenv"] = dotenv
+
+    if "aiogram" not in sys.modules:
+        aiogram = types.ModuleType("aiogram")
+
+        class DummyBot:  # pragma: no cover - helpers for import only
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def send_message(self, *args, **kwargs):
+                return None
+
+        class DummyDispatcher:  # pragma: no cover - helpers for import only
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __getattr__(self, _name):
+                def decorator(*_args, **_kwargs):
+                    def wrapper(func):
+                        return func
+
+                    return wrapper
+
+                return decorator
+
+        aiogram.Bot = DummyBot
+        aiogram.Dispatcher = DummyDispatcher
+
+        types_module = types.ModuleType("aiogram.types")
+
+        class DummyMessage:  # pragma: no cover - helpers for import only
+            pass
+
+        types_module.Message = DummyMessage
+        types_module.CallbackQuery = type("CallbackQuery", (), {})
+
+        def _auto_dummy(attr_name):
+            dummy_type = type(attr_name, (), {})
+            setattr(types_module, attr_name, dummy_type)
+            return dummy_type
+
+        types_module.__getattr__ = staticmethod(_auto_dummy)
+        sys.modules["aiogram.types"] = types_module
+        aiogram.types = types_module
+
+        filters_module = types.ModuleType("aiogram.filters")
+
+        class DummyCommand:  # pragma: no cover - helpers for import only
+            def __init__(self, *args, **kwargs):
+                pass
+
+        class DummyCommandStart(DummyCommand):
+            pass
+
+        filters_module.Command = DummyCommand
+        filters_module.CommandStart = DummyCommandStart
+        sys.modules["aiogram.filters"] = filters_module
+
+        fsm_module = types.ModuleType("aiogram.fsm")
+        storage_module = types.ModuleType("aiogram.fsm.storage")
+        memory_module = types.ModuleType("aiogram.fsm.storage.memory")
+
+        class DummyMemoryStorage:  # pragma: no cover - helpers for import only
+            def __init__(self, *args, **kwargs):
+                pass
+
+        memory_module.MemoryStorage = DummyMemoryStorage
+        storage_module.memory = memory_module
+        fsm_module.storage = storage_module
+        sys.modules["aiogram.fsm"] = fsm_module
+        sys.modules["aiogram.fsm.storage"] = storage_module
+        sys.modules["aiogram.fsm.storage.memory"] = memory_module
+
+        context_module = types.ModuleType("aiogram.fsm.context")
+
+        class DummyFSMContext:  # pragma: no cover - helpers for import only
+            async def get_data(self):
+                return {}
+
+            async def update_data(self, *args, **kwargs):
+                return None
+
+            async def set_state(self, *args, **kwargs):
+                return None
+
+            async def clear(self):
+                return None
+
+        context_module.FSMContext = DummyFSMContext
+        sys.modules["aiogram.fsm.context"] = context_module
+
+        state_module = types.ModuleType("aiogram.fsm.state")
+
+        class DummyState:  # pragma: no cover - helpers for import only
+            pass
+
+        class DummyStatesGroup:  # pragma: no cover - helpers for import only
+            pass
+
+        state_module.State = DummyState
+        state_module.StatesGroup = DummyStatesGroup
+        sys.modules["aiogram.fsm.state"] = state_module
+
+        utils_module = types.ModuleType("aiogram.utils")
+        keyboard_module = types.ModuleType("aiogram.utils.keyboard")
+
+        class DummyInlineKeyboardBuilder:  # pragma: no cover - helpers for import only
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def row(self, *args, **kwargs):
+                return None
+
+            def as_markup(self):
+                return None
+
+        keyboard_module.InlineKeyboardBuilder = DummyInlineKeyboardBuilder
+        utils_module.keyboard = keyboard_module
+        sys.modules["aiogram.utils"] = utils_module
+        sys.modules["aiogram.utils.keyboard"] = keyboard_module
+
+        aiogram.filters = filters_module
+        aiogram.fsm = fsm_module
+        aiogram.utils = utils_module
+        sys.modules["aiogram"] = aiogram
+
+
+def _load_main_module():
+    _ensure_stubbed_dependencies()
+    if "main" in sys.modules:
+        return sys.modules["main"]
+    original_run = asyncio.run
+
+    def _dummy_run(coro, *args, **kwargs):  # type: ignore[override]
+        try:
+            coro.close()
+        except Exception:
+            pass
+        return None
+
+    asyncio.run = _dummy_run  # type: ignore[assignment]
+    try:
+        return importlib.import_module("main")
+    finally:
+        asyncio.run = original_run
+
+
+def _make_settings(main_module):
+    return main_module.WarmupSettingsData(
+        channels_per_day=3,
+        delay_minutes=10,
+        join_start_hour=12,
+        join_start_minute=0,
+        join_end_hour=19,
+        join_end_minute=0,
+    )
+
+
+def test_plan_next_after_daily_limit(monkeypatch):
+    main_module = _load_main_module()
+    settings = _make_settings(main_module)
+
+    monkeypatch.setattr(main_module, "_get_human_delay_seconds", lambda *args, **kwargs: 300)
+
+    now = datetime(2024, 1, 1, 18, 0, tzinfo=timezone.utc)
+    next_window_start = main_module._next_join_window_start(now, settings)
+    planned = main_module.plan_next_warmup_join(next_window_start, settings)
+
+    assert planned >= next_window_start
+    window_end = datetime.combine(
+        next_window_start.date(),
+        settings.window_end,
+        tzinfo=timezone.utc,
+    )
+    assert planned < window_end
+    assert planned.date() == next_window_start.date()
+
+
+def test_plan_next_near_window_end(monkeypatch):
+    main_module = _load_main_module()
+    settings = _make_settings(main_module)
+
+    monkeypatch.setattr(main_module, "_get_human_delay_seconds", lambda *args, **kwargs: 900)
+
+    window_end_today = datetime(2024, 1, 1, settings.join_end_hour, settings.join_end_minute, tzinfo=timezone.utc)
+    earliest = window_end_today - timedelta(minutes=2)
+    planned = main_module.plan_next_warmup_join(earliest, settings)
+
+    next_window_start = datetime(2024, 1, 2, settings.join_start_hour, settings.join_start_minute, tzinfo=timezone.utc)
+    assert planned >= next_window_start
+    next_window_end = datetime(2024, 1, 2, settings.join_end_hour, settings.join_end_minute, tzinfo=timezone.utc)
+    assert planned < next_window_end


### PR DESCRIPTION
## Summary
- align warmup scheduling with window boundaries and ensure next attempts move to the next available window
- log scheduled join times after persisting updates
- add tests for warmup planner edge cases using stubbed dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0231a88bc8330b551d7eb5ab87483