### PR TITLE
Handle regular channel joins with success tracking

### DIFF
--- a/main.py
+++ b/main.py
@@ -1517,15 +1517,25 @@ async def send_comments(userid, session, account_id):
             quiet_sessions_notified.discard(key)
 
 
-async def join_channel(channel: str, account_id: int, session_key: str, user_id: int, is_warmup: bool = False) -> bool:
-    """Единая функция для вступления в канал (обычный или прогрев)"""
+async def join_channel(
+    channel: str,
+    account_id: int,
+    session_key: str,
+    user_id: int,
+    is_warmup: bool = False,
+) -> Tuple[bool, Optional[str]]:
+    """Единая функция для вступления в канал (обычный или прогрев).
+
+    Возвращает кортеж `(успех, причина_ошибки)`.
+    """
     try:
         # Создаем клиент
         session_file = os.path.join("sessions", str(user_id), f"{session_key}.session")
         if not os.path.exists(session_file):
-            await bot.send_message(log_channel, f"Аккаунт {session_key} - файл сессии не найден: {session_file}")
-            return False
-            
+            error_message = f"Аккаунт {session_key} - файл сессии не найден: {session_file}"
+            await bot.send_message(log_channel, error_message)
+            return False, error_message
+
         client = Client(
             name=session_file,
             api_id=API_ID,
@@ -1544,29 +1554,30 @@ async def join_channel(channel: str, account_id: int, session_key: str, user_id:
                 else:
                     # Для обычных каналов - просто логируем
                     await bot.send_message(log_channel, f"Аккаунт {session_key} вступил в канал: {channel}")
-                
-                return True
-                
+
+                return True, None
+
             except UserAlreadyParticipant:
                 if is_warmup:
                     await mark_warmup_channel_joined(account_id, channel)
                 await bot.send_message(log_channel, f"Аккаунт {session_key} уже состоит в канале: {channel}")
-                return True
-                
+                return True, None
+
             except Exception as e:
+                error_message = str(e)
                 if is_warmup:
-                    await record_warmup_channel_error(account_id, channel, str(e))
+                    await record_warmup_channel_error(account_id, channel, error_message)
                 await bot.send_message(log_channel, f"Аккаунт {session_key} ошибка вступления в канал {channel}: {e}")
-                return False
-                
+                return False, error_message
+
     except Exception as e:
         error_msg = str(e)
         if any(keyword in error_msg.lower() for keyword in ["phone number", "auth", "eof when reading", "session", "unauthorized"]):
             await bot.send_message(log_channel, f"Аккаунт {session_key} - сессия истекла или повреждена: {error_msg}")
-            return False
+            return False, error_msg
         else:
             await bot.send_message(log_channel, f"Аккаунт {session_key} ошибка подключения: {e}")
-            return False
+            return False, error_msg
 
 
 async def process_warmup_accounts():
@@ -1676,7 +1687,7 @@ async def process_warmup_accounts():
                     continue
 
                 # Используем единую функцию для вступления в канал прогрева
-                success = await join_channel(channel, account["id"], session_key, user_id, is_warmup=True)
+                success, error_reason = await join_channel(channel, account["id"], session_key, user_id, is_warmup=True)
 
                 if not success:
                     # Если сессия истекла - переключаем в стандартный режим
@@ -1792,16 +1803,35 @@ async def add_regular_channels(message: Message, state: FSMContext) -> None:
         await main_message(message)
         return
 
-    channels_to_update = None
+    channels_to_update: Optional[List[str]] = None
+    successful_channels: List[str] = []
     if str(message.text) != '-':
         channels = [line.strip() for line in message.text.splitlines() if line.strip()]
 
         # Вступаем в обычные каналы сразу
         for channel in channels:
-            await join_channel(channel, account_id, session, message.from_user.id, is_warmup=False)
+            success, error_reason = await join_channel(
+                channel, account_id, session, message.from_user.id, is_warmup=False
+            )
 
-        # Обновляем список обычных каналов в БД
-        channels_to_update = channels
+            if success:
+                successful_channels.append(channel)
+            else:
+                reason_text = error_reason or "Неизвестная ошибка"
+                await bot.send_message(
+                    log_channel,
+                    f"Не удалось добавить канал {channel} для аккаунта {session}: {reason_text}",
+                )
+                await bot.send_message(
+                    message.from_user.id,
+                    f"Не удалось вступить в канал {channel}: {reason_text}",
+                )
+
+        # Обновляем список обычных каналов в БД только успешными каналами
+        if successful_channels:
+            channels_to_update = successful_channels
+    else:
+        channels = []
 
     sleep_min, sleep_max = None, None
     if sleeps:
@@ -1819,6 +1849,16 @@ async def add_regular_channels(message: Message, state: FSMContext) -> None:
         update_kwargs["channels"] = channels_to_update
 
     await update_account_settings(account_id, **update_kwargs)
+
+    if successful_channels:
+        channels_summary = "\n".join(successful_channels)
+        summary_text = "Итоговый список успешно добавленных каналов:\n" + channels_summary
+    elif str(message.text) == '-':
+        summary_text = "Каналы не были добавлены."
+    else:
+        summary_text = "Не удалось добавить ни один канал."
+
+    await bot.send_message(message.from_user.id, summary_text)
 
     # Переходим к диалогу каналов прогрева
     await bot.send_message(message.from_user.id, 'Теперь пришлите каналы для прогрева (каждый канал с новой строки). Для отмены отправьте "-".')
@@ -2241,6 +2281,7 @@ async def main():
         raise
 
 
-asyncio.run(main())
-# asyncio.run(bot.run())
+if __name__ == "__main__":
+    asyncio.run(main())
+    # asyncio.run(bot.run())
 

--- a/test_add_regular_channels.py
+++ b/test_add_regular_channels.py
@@ -1,0 +1,89 @@
+import os
+import types
+from typing import Any, Dict
+
+import pytest
+
+os.environ.setdefault("API_ID", "1")
+os.environ.setdefault("API_HASH", "test")
+os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
+
+import main
+
+
+class DummyState:
+    def __init__(self, data: Dict[str, Any]):
+        self._data = data
+        self.cleared = False
+        self.next_state = None
+
+    async def get_data(self) -> Dict[str, Any]:
+        return self._data
+
+    async def clear(self) -> None:
+        self.cleared = True
+
+    async def set_state(self, state: Any) -> None:
+        self.next_state = state
+
+    async def update_data(self, data: Dict[str, Any]) -> None:
+        self._data.update(data)
+
+
+class DummyMessage:
+    def __init__(self, text: str, user_id: int):
+        self.text = text
+        self.from_user = types.SimpleNamespace(id=user_id)
+
+
+@pytest.mark.asyncio
+async def test_add_regular_channels_success_and_failure(monkeypatch):
+    state_data = {
+        "account": "test_session",
+        "account_id": 123,
+        "chance": 25,
+        "systempromt": "Test prompt",
+        "sleeps": "5-10",
+    }
+    state = DummyState(state_data)
+    message = DummyMessage("@good\n@bad", user_id=42)
+
+    recorded_messages = []
+
+    class DummyBot:
+        async def send_message(self, chat_id: int, text: str, **kwargs: Any) -> None:
+            recorded_messages.append((chat_id, text))
+
+    async def fake_join_channel(channel, account_id, session_key, user_id, is_warmup=False):
+        if channel == "@good":
+            return True, None
+        return False, "Ошибка доступа"
+
+    captured_update = {}
+
+    async def fake_update_account_settings(account_id: int, **kwargs: Any) -> None:
+        captured_update["account_id"] = account_id
+        captured_update["kwargs"] = kwargs
+
+    monkeypatch.setattr(main, "bot", DummyBot())
+    monkeypatch.setattr(main, "log_channel", 999)
+    monkeypatch.setattr(main, "join_channel", fake_join_channel)
+    monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
+    monkeypatch.setattr(main, "startaccount", types.SimpleNamespace(warmup_channels="warmup_state"))
+
+    await main.add_regular_channels(message, state)
+
+    assert captured_update["account_id"] == 123
+    assert captured_update["kwargs"]["channels"] == ["@good"]
+    assert captured_update["kwargs"]["chance"] == 25
+    assert captured_update["kwargs"]["system_prompt"] == "Test prompt"
+    assert captured_update["kwargs"]["sleep_min"] == 5
+    assert captured_update["kwargs"]["sleep_max"] == 10
+
+    failure_notifications = [msg for msg in recorded_messages if "Не удалось вступить" in msg[1]]
+    assert failure_notifications, "Пользователь должен получать уведомление об ошибке"
+
+    summaries = [msg for msg in recorded_messages if "Итоговый список успешно добавленных каналов" in msg[1]]
+    assert summaries, "Пользователь должен получать итоговый список каналов"
+
+    assert state.next_state == "warmup_state"


### PR DESCRIPTION
## Summary
- update `join_channel` to return success/error details and reuse them in regular channel flow
- only persist successfully joined regular channels, notify about failures, and send a summary message to the user
- add an async test covering mixed success/failure channel additions and guard the main entrypoint for imports

## Testing
- pytest test_add_regular_channels.py

------
https://chatgpt.com/codex/tasks/task_e_68e026ccc21c8330be716e3b5432086a