### PR TITLE
Handle merging of regular channels with existing list

### DIFF
--- a/main.py
+++ b/main.py
@@ -1789,12 +1789,17 @@ async def add_code(message: Message, state: FSMContext) -> None:
 @dp.message(startaccount.regular_channels)
 async def add_regular_channels(message: Message, state: FSMContext) -> None:
     """Обработчик для обычных каналов (немедленное вступление)"""
-    data = await state.get_data()
-    session = data.get("account")
-    account_id = data.get("account_id")
-    chance = data.get("chance")
-    system_prompt_value = data.get("systempromt")
-    sleeps = data.get("sleeps")
+    data, account_id, account = await _load_account_data(state)
+    session = data.get("account") if data else None
+    chance = data.get("chance") if data else None
+    system_prompt_value = data.get("systempromt") if data else None
+    sleeps = data.get("sleeps") if data else None
+
+    existing_channels_raw = []
+    if account and isinstance(account, dict):
+        stored_channels = account.get("channels")
+        if isinstance(stored_channels, list):
+            existing_channels_raw = [channel for channel in stored_channels if isinstance(channel, str)]
 
     if not account_id:
         await bot.send_message(message.from_user.id, "Ошибка: аккаунт не найден. Попробуйте снова.")
@@ -1828,7 +1833,29 @@ async def add_regular_channels(message: Message, state: FSMContext) -> None:
 
         # Обновляем список обычных каналов в БД только успешными каналами
         if successful_channels:
-            channels_to_update = successful_channels
+            def _merge_channels(
+                existing: List[str], new: List[str]
+            ) -> Tuple[List[str], bool]:
+                seen: Set[str] = set()
+                merged_list: List[str] = []
+
+                for item in existing:
+                    if item not in seen:
+                        merged_list.append(item)
+                        seen.add(item)
+
+                added = False
+                for item in new:
+                    if item not in seen:
+                        merged_list.append(item)
+                        seen.add(item)
+                        added = True
+
+                return merged_list, added
+
+            merged_channels, has_new_channels = _merge_channels(existing_channels_raw, successful_channels)
+            if has_new_channels:
+                channels_to_update = merged_channels
     else:
         channels = []
 

--- a/test_add_regular_channels.py
+++ b/test_add_regular_channels.py
@@ -1,8 +1,7 @@
+import asyncio
 import os
 import types
 from typing import Any, Dict
-
-import pytest
 
 os.environ.setdefault("API_ID", "1")
 os.environ.setdefault("API_HASH", "test")
@@ -36,8 +35,7 @@ class DummyMessage:
         self.from_user = types.SimpleNamespace(id=user_id)
 
 
-@pytest.mark.asyncio
-async def test_add_regular_channels_success_and_failure(monkeypatch):
+def test_add_regular_channels_success_and_failure(monkeypatch):
     state_data = {
         "account": "test_session",
         "account_id": 123,
@@ -65,16 +63,20 @@ async def test_add_regular_channels_success_and_failure(monkeypatch):
         captured_update["account_id"] = account_id
         captured_update["kwargs"] = kwargs
 
+    async def fake_load_account_data(dummy_state):
+        return state_data, state_data["account_id"], {"channels": ["@existing"]}
+
     monkeypatch.setattr(main, "bot", DummyBot())
     monkeypatch.setattr(main, "log_channel", 999)
     monkeypatch.setattr(main, "join_channel", fake_join_channel)
     monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
     monkeypatch.setattr(main, "startaccount", types.SimpleNamespace(warmup_channels="warmup_state"))
+    monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
 
-    await main.add_regular_channels(message, state)
+    asyncio.run(main.add_regular_channels(message, state))
 
     assert captured_update["account_id"] == 123
-    assert captured_update["kwargs"]["channels"] == ["@good"]
+    assert captured_update["kwargs"]["channels"] == ["@existing", "@good"]
     assert captured_update["kwargs"]["chance"] == 25
     assert captured_update["kwargs"]["system_prompt"] == "Test prompt"
     assert captured_update["kwargs"]["sleep_min"] == 5


### PR DESCRIPTION
## Summary
- load existing regular channels from account data before joining new ones
- merge successful joins with the stored list while avoiding duplicates and skipping updates when nothing new is added
- update the regular channel handler test to cover the merge logic without requiring pytest-asyncio

## Testing
- pytest test_add_regular_channels.py

------
https://chatgpt.com/codex/tasks/task_e_68e02b7d8af08330ac970a6b4bce3ad9