### PR TITLE
Log random roll when skipping comments

### DIFF
--- a/main.py
+++ b/main.py
@@ -1459,8 +1459,9 @@ async def send_comments(userid, session, account_id):
             if (message.chat.permissions.can_send_messages is True) and (
                     message.text is not None or message.caption is not None):
                 
-                if random.randint(1, 100) > chance:
-                    await bot.send_message(log_channel, f'Аккаунт {session} пропустил комментарий')
+                roll = random.randint(1, 100)
+                if roll > chance:
+                    await bot.send_message(log_channel, f'Аккаунт {session} пропустил комментарий (rnd {roll} > {chance})')
                     return
 
                 post_text = message.text or message.caption


### PR DESCRIPTION
## Summary
- store the random roll when deciding to skip commenting
- include the roll and chance in the skip log message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e038e7c8b48330bbdc406c2634b888