### PR TITLE
Handle warmup queue skip command

### DIFF
--- a/main.py
+++ b/main.py
@@ -783,7 +783,7 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
             warmup_display,
             "",
             "Отправьте каналы для прогрева (каждый канал на новой строке).",
-            "Отправьте '-' чтобы очистить очередь и перевести аккаунт в стандартный режим.",
+            "Отправьте '-' чтобы оставить очередь без изменений или 'clear' для очистки и перехода в стандартный режим.",
         ]
 
         await bot.send_message(
@@ -1054,29 +1054,42 @@ async def manage_warmup_channels(message: Message, state: FSMContext) -> None:
 
     incoming = (message.text or "").strip()
     if not incoming:
-        await message.answer("Пришлите список каналов или '-' для очистки очереди.")
+        await message.answer(
+            "Пришлите список каналов, '-' чтобы оставить очередь без изменений или 'clear' для очистки."
+        )
         return
 
+    normalized = incoming.lower()
     if incoming == "-":
-        channels: List[str] = []
+        channels: Optional[List[str]] = None
+    elif normalized == "clear":
+        channels = []
     else:
         channels = [line.strip() for line in incoming.splitlines() if line.strip()]
 
-    seen: Set[str] = set()
-    unique_channels: List[str] = []
-    for channel in channels:
-        if channel not in seen:
-            seen.add(channel)
-            unique_channels.append(channel)
+    unique_channels: Optional[List[str]]
+    if channels is None:
+        unique_channels = None
+    else:
+        seen: Set[str] = set()
+        deduped: List[str] = []
+        for channel in channels:
+            if channel not in seen:
+                seen.add(channel)
+                deduped.append(channel)
+        unique_channels = deduped
 
     try:
-        await sync_warmup_channels(account_id, unique_channels)
-        if unique_channels:
-            await set_account_mode(account_id, "warmup", warmup_days=WARMUP_DEFAULT_DAYS)
-            result_text = f"Очередь прогрева обновлена. Запланировано {len(unique_channels)} каналов."
+        if unique_channels is None:
+            result_text = "Очередь прогрева не изменена."
         else:
-            await set_account_mode(account_id, "standard", warmup_days=None)
-            result_text = "Очередь прогрева очищена. Аккаунт переведён в стандартный режим."
+            await sync_warmup_channels(account_id, unique_channels)
+            if unique_channels:
+                await set_account_mode(account_id, "warmup", warmup_days=WARMUP_DEFAULT_DAYS)
+                result_text = f"Очередь прогрева обновлена. Запланировано {len(unique_channels)} каналов."
+            else:
+                await set_account_mode(account_id, "standard", warmup_days=None)
+                result_text = "Очередь прогрева очищена. Аккаунт переведён в стандартный режим."
     except Exception as exc:
         await message.answer(f"Ошибка при обновлении каналов прогрева: {exc}")
         await state.clear()

--- a/test_manage_warmup_channels.py
+++ b/test_manage_warmup_channels.py
@@ -1,0 +1,68 @@
+import asyncio
+import os
+import types
+from typing import Any, Dict
+
+os.environ.setdefault("API_ID", "1")
+os.environ.setdefault("API_HASH", "test")
+os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
+
+import main
+
+
+class DummyState:
+    def __init__(self, data: Dict[str, Any]):
+        self._data = data
+        self.cleared = False
+
+    async def get_data(self) -> Dict[str, Any]:
+        return self._data
+
+    async def clear(self) -> None:
+        self.cleared = True
+
+
+class DummyMessage:
+    def __init__(self, text: str, user_id: int = 1):
+        self.text = text
+        self.from_user = types.SimpleNamespace(id=user_id)
+        self.answers = []
+
+    async def answer(self, text: str, **kwargs: Any) -> None:
+        self.answers.append(text)
+
+
+def test_manage_warmup_channels_dash_keeps_queue(monkeypatch):
+    state = DummyState({"account": "session", "account_id": 42})
+    message = DummyMessage("-")
+
+    calls: Dict[str, Any] = {"sync": False, "mode": [], "main_message": False}
+
+    async def fake_sync(account_id: int, channels: Any) -> None:
+        calls["sync"] = True
+
+    async def fake_set_account_mode(account_id: int, mode: str, **kwargs: Any) -> None:
+        calls["mode"].append((account_id, mode, kwargs))
+
+    async def fake_get_pending(account_id: int, limit: int = 100):
+        return [{"channel": "@one"}, {"channel": "@two"}]
+
+    async def fake_format(channels, title="Каналы", max_display=10):
+        return f"{title}: {', '.join(channels)}" if channels else f"{title}: нет"
+
+    async def fake_main_message(msg):
+        calls["main_message"] = True
+
+    monkeypatch.setattr(main, "sync_warmup_channels", fake_sync)
+    monkeypatch.setattr(main, "set_account_mode", fake_set_account_mode)
+    monkeypatch.setattr(main, "get_warmup_pending", fake_get_pending)
+    monkeypatch.setattr(main, "format_channels_display", fake_format)
+    monkeypatch.setattr(main, "main_message", fake_main_message)
+
+    asyncio.run(main.manage_warmup_channels(message, state))
+
+    assert not calls["sync"], "Очередь не должна обновляться при вводе '-'"
+    assert not calls["mode"], "Режим аккаунта не должен меняться при вводе '-'"
+    assert state.cleared, "Состояние должно очищаться после обработки"
+    assert calls["main_message"], "Должен показываться главный экран после обработки"
+    assert any("не изменена" in ans for ans in message.answers), "Пользователь должен получать уведомление об отсутствии изменений"


### PR DESCRIPTION
## Summary
- treat '-' as leaving the warmup queue unchanged and require 'clear' to reset it
- update the warmup queue prompt to describe the new behavior
- add a regression test to ensure '-' no longer clears the warmup queue

## Testing
- pytest test_manage_warmup_channels.py

------
https://chatgpt.com/codex/tasks/task_e_68e0c4b035988330b085aa7017f4d6ac