### PR TITLE
Ensure warmup queue dash restarts warmup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1010,7 +1010,7 @@ async def manage_warmup_channels(message: Message, state: FSMContext) -> None:
     incoming = (message.text or "").strip()
     if not incoming:
         await message.answer(
-            "Пришлите список каналов, '-' чтобы оставить очередь без изменений или 'clear' для очистки."
+            "Пришлите список каналов, '-' чтобы оставить очередь и при наличии каналов перезапустить прогрев, или 'clear' для очистки."
         )
         return
 
@@ -1040,10 +1040,8 @@ async def manage_warmup_channels(message: Message, state: FSMContext) -> None:
         else:
             await sync_warmup_channels(account_id, unique_channels)
             if unique_channels:
-                await set_account_mode(account_id, "warmup", warmup_days=WARMUP_DEFAULT_DAYS)
                 result_text = f"Очередь прогрева обновлена. Запланировано {len(unique_channels)} каналов."
             else:
-                await set_account_mode(account_id, "standard", warmup_days=None)
                 result_text = "Очередь прогрева очищена. Аккаунт переведён в стандартный режим."
     except Exception as exc:
         await message.answer(f"Ошибка при обновлении каналов прогрева: {exc}")
@@ -1052,6 +1050,13 @@ async def manage_warmup_channels(message: Message, state: FSMContext) -> None:
         return
 
     updated_records = await get_warmup_pending(account_id, limit=100)
+    if updated_records:
+        warmup_settings = await ensure_latest_warmup_settings()
+        await set_account_mode(account_id, "warmup", warmup_days=WARMUP_DEFAULT_DAYS)
+        next_join = plan_next_warmup_join(datetime.now(timezone.utc), warmup_settings)
+        await db_update_warmup_schedule(account_id, next_join=next_join)
+    else:
+        await set_account_mode(account_id, "standard", warmup_days=None)
     updated_list = [entry["channel"] for entry in updated_records] if updated_records else []
     display = await format_channels_display(updated_list, "Очередь прогрева", 10)
 

--- a/test_manage_warmup_channels.py
+++ b/test_manage_warmup_channels.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import types
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 os.environ.setdefault("API_ID", "1")
@@ -32,11 +33,19 @@ class DummyMessage:
         self.answers.append(text)
 
 
-def test_manage_warmup_channels_dash_keeps_queue(monkeypatch):
+def test_manage_warmup_channels_dash_keeps_queue_and_resets_schedule(monkeypatch):
     state = DummyState({"account": "session", "account_id": 42})
     message = DummyMessage("-")
 
-    calls: Dict[str, Any] = {"sync": False, "mode": [], "main_message": False}
+    sentinel_next = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    calls: Dict[str, Any] = {
+        "sync": False,
+        "mode": [],
+        "main_message": False,
+        "plan": None,
+        "db_update": None,
+    }
 
     async def fake_sync(account_id: int, channels: Any) -> None:
         calls["sync"] = True
@@ -47,6 +56,16 @@ def test_manage_warmup_channels_dash_keeps_queue(monkeypatch):
     async def fake_get_pending(account_id: int, limit: int = 100):
         return [{"channel": "@one"}, {"channel": "@two"}]
 
+    async def fake_ensure_latest_warmup_settings(force: bool = False):
+        return "settings"
+
+    def fake_plan_next_warmup_join(now, settings):
+        calls["plan"] = (now, settings)
+        return sentinel_next
+
+    async def fake_db_update(account_id: int, *, next_join=None, last_join=None):
+        calls["db_update"] = {"account_id": account_id, "next_join": next_join, "last_join": last_join}
+
     async def fake_format(channels, title="Каналы", max_display=10):
         return f"{title}: {', '.join(channels)}" if channels else f"{title}: нет"
 
@@ -56,13 +75,72 @@ def test_manage_warmup_channels_dash_keeps_queue(monkeypatch):
     monkeypatch.setattr(main, "sync_warmup_channels", fake_sync)
     monkeypatch.setattr(main, "set_account_mode", fake_set_account_mode)
     monkeypatch.setattr(main, "get_warmup_pending", fake_get_pending)
+    monkeypatch.setattr(main, "ensure_latest_warmup_settings", fake_ensure_latest_warmup_settings)
+    monkeypatch.setattr(main, "plan_next_warmup_join", fake_plan_next_warmup_join)
+    monkeypatch.setattr(main, "db_update_warmup_schedule", fake_db_update)
     monkeypatch.setattr(main, "format_channels_display", fake_format)
     monkeypatch.setattr(main, "main_message", fake_main_message)
 
     asyncio.run(main.manage_warmup_channels(message, state))
 
     assert not calls["sync"], "Очередь не должна обновляться при вводе '-'"
-    assert not calls["mode"], "Режим аккаунта не должен меняться при вводе '-'"
+    assert calls["mode"] == [(42, "warmup", {"warmup_days": main.WARMUP_DEFAULT_DAYS})]
+    assert calls["plan"] is not None, "Должно обновляться расписание прогрева"
+    assert calls["db_update"] == {"account_id": 42, "next_join": sentinel_next, "last_join": None}
     assert state.cleared, "Состояние должно очищаться после обработки"
     assert calls["main_message"], "Должен показываться главный экран после обработки"
     assert any("не изменена" in ans for ans in message.answers), "Пользователь должен получать уведомление об отсутствии изменений"
+
+
+def test_manage_warmup_channels_clear_switches_to_standard(monkeypatch):
+    state = DummyState({"account": "session", "account_id": 99})
+    message = DummyMessage("clear")
+
+    calls: Dict[str, Any] = {
+        "sync": None,
+        "mode": [],
+        "plan": False,
+        "db_update": False,
+    }
+
+    async def fake_sync(account_id: int, channels: Any) -> None:
+        calls["sync"] = (account_id, channels)
+
+    async def fake_set_account_mode(account_id: int, mode: str, **kwargs: Any) -> None:
+        calls["mode"].append((account_id, mode, kwargs))
+
+    async def fake_get_pending(account_id: int, limit: int = 100):
+        return []
+
+    async def fake_ensure_latest_warmup_settings(force: bool = False):
+        calls["plan"] = True
+        return "settings"
+
+    def fake_plan_next_warmup_join(now, settings):
+        calls["plan"] = True
+        return datetime.now(timezone.utc)
+
+    async def fake_db_update(account_id: int, *, next_join=None, last_join=None):
+        calls["db_update"] = True
+
+    async def fake_format(channels, title="Каналы", max_display=10):
+        return "Очередь: нет"
+
+    async def fake_main_message(msg):
+        pass
+
+    monkeypatch.setattr(main, "sync_warmup_channels", fake_sync)
+    monkeypatch.setattr(main, "set_account_mode", fake_set_account_mode)
+    monkeypatch.setattr(main, "get_warmup_pending", fake_get_pending)
+    monkeypatch.setattr(main, "ensure_latest_warmup_settings", fake_ensure_latest_warmup_settings)
+    monkeypatch.setattr(main, "plan_next_warmup_join", fake_plan_next_warmup_join)
+    monkeypatch.setattr(main, "db_update_warmup_schedule", fake_db_update)
+    monkeypatch.setattr(main, "format_channels_display", fake_format)
+    monkeypatch.setattr(main, "main_message", fake_main_message)
+
+    asyncio.run(main.manage_warmup_channels(message, state))
+
+    assert calls["sync"] == (99, []), "Очередь должна очищаться"
+    assert calls["mode"] == [(99, "standard", {"warmup_days": None})]
+    assert calls["plan"] is False, "Не должно планироваться расписание при пустой очереди"
+    assert calls["db_update"] is False, "Не должно обновляться расписание при пустой очереди"


### PR DESCRIPTION
## Summary
- restart warmup mode when a non-empty queue remains after managing warmup channels and refresh the next join schedule
- clarify the warmup channel management prompt about using '-' to keep the queue
- extend warmup channel management tests to cover schedule refresh and clearing behaviour

## Testing
- pytest test_manage_warmup_channels.py

------
https://chatgpt.com/codex/tasks/task_e_68e0cea2c82c83309d5f5af2883654ce