### PR TITLE
Add inline clear control for warmup queue

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import random
 from pyrogram import Client, filters
 from pyrogram.errors import UserAlreadyParticipant
 from aiogram import Bot, Dispatcher, types
-from aiogram.types import Message
+from aiogram.types import Message, InlineKeyboardButton, InlineKeyboardMarkup
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.filters import CommandStart, Command
 from aiogram.fsm.context import FSMContext
@@ -715,6 +715,32 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
         return
 
 
+    elif call.startswith('warmclear_'):
+        await callback_query.answer()
+        session = str(call).split('_', 1)[1]
+        account_row = await get_account_by_session(callback_query.from_user.id, session)
+        if not account_row:
+            await bot.send_message(callback_query.from_user.id, "Аккаунт не найден в базе данных")
+            await state.clear()
+            await main_message(callback_query)
+            return
+
+        account_id = account_row["id"]
+
+        try:
+            await sync_warmup_channels(account_id, [])
+            await set_account_mode(account_id, "standard", warmup_days=None)
+            confirmation_text = (
+                f"Очередь прогрева для {session} очищена. Аккаунт переведён в стандартный режим."
+            )
+        except Exception as exc:
+            confirmation_text = f"Не удалось очистить очередь прогрева: {exc}"
+
+        await bot.send_message(callback_query.from_user.id, confirmation_text)
+        await state.clear()
+        await main_message(callback_query)
+        return
+
     elif call.startswith('warmup_'):
         await callback_query.answer()
         session = str(call).split('_', 1)[1]
@@ -738,12 +764,19 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
             warmup_display,
             "",
             "Отправьте каналы для прогрева (каждый канал на новой строке).",
-            "Отправьте '-' чтобы оставить очередь без изменений или 'clear' для очистки и перехода в стандартный режим.",
+            "Отправьте '-' чтобы оставить очередь без изменений или воспользуйтесь кнопкой Clear для очистки и перехода в стандартный режим.",
         ]
+
+        keyboard = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text="Clear", callback_data=f"warmclear_{session}")]
+            ]
+        )
 
         await bot.send_message(
             callback_query.from_user.id,
             "\n".join(line for line in prompt_lines if line),
+            reply_markup=keyboard,
         )
         return
 
@@ -1010,7 +1043,7 @@ async def manage_warmup_channels(message: Message, state: FSMContext) -> None:
     incoming = (message.text or "").strip()
     if not incoming:
         await message.answer(
-            "Пришлите список каналов, '-' чтобы оставить очередь и при наличии каналов перезапустить прогрев, или 'clear' для очистки."
+            "Пришлите список каналов, '-' чтобы оставить очередь и при наличии каналов перезапустить прогрев, или воспользуйтесь кнопкой Clear для очистки."
         )
         return
 

--- a/test_manage_warmup_channels.py
+++ b/test_manage_warmup_channels.py
@@ -33,6 +33,25 @@ class DummyMessage:
         self.answers.append(text)
 
 
+class DummyCallback:
+    def __init__(self, data: str, user_id: int = 1):
+        self.data = data
+        self.from_user = types.SimpleNamespace(id=user_id)
+        self._deleted = False
+        self.message = types.SimpleNamespace(delete=self._delete)
+        self.answered = False
+        self.answer_text = None
+        self.answer_kwargs: Dict[str, Any] = {}
+
+    async def _delete(self) -> None:
+        self._deleted = True
+
+    async def answer(self, text: str | None = None, **kwargs: Any) -> None:
+        self.answered = True
+        self.answer_text = text
+        self.answer_kwargs = kwargs
+
+
 def test_manage_warmup_channels_dash_keeps_queue_and_resets_schedule(monkeypatch):
     state = DummyState({"account": "session", "account_id": 42})
     message = DummyMessage("-")
@@ -144,3 +163,46 @@ def test_manage_warmup_channels_clear_switches_to_standard(monkeypatch):
     assert calls["mode"] == [(99, "standard", {"warmup_days": None})]
     assert calls["plan"] is False, "Не должно планироваться расписание при пустой очереди"
     assert calls["db_update"] is False, "Не должно обновляться расписание при пустой очереди"
+
+
+def test_warmclear_callback_clears_queue_and_state(monkeypatch):
+    state = DummyState({"account": "session", "account_id": 77})
+    callback = DummyCallback("warmclear_session")
+
+    calls: Dict[str, Any] = {
+        "sync": None,
+        "mode": None,
+        "messages": [],
+        "main_message": False,
+    }
+
+    async def fake_get_account_by_session(user_id: int, session: str):
+        assert session == "session"
+        return {"id": 77}
+
+    async def fake_sync(account_id: int, channels: Any) -> None:
+        calls["sync"] = (account_id, channels)
+
+    async def fake_set_mode(account_id: int, mode: str, **kwargs: Any) -> None:
+        calls["mode"] = (account_id, mode, kwargs)
+
+    async def fake_send_message(user_id: int, text: str, **kwargs: Any) -> None:
+        calls["messages"].append((user_id, text, kwargs))
+
+    async def fake_main_message(msg):
+        calls["main_message"] = True
+
+    monkeypatch.setattr(main, "get_account_by_session", fake_get_account_by_session)
+    monkeypatch.setattr(main, "sync_warmup_channels", fake_sync)
+    monkeypatch.setattr(main, "set_account_mode", fake_set_mode)
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+    monkeypatch.setattr(main, "main_message", fake_main_message)
+
+    asyncio.run(main.callbacks(callback, state))
+
+    assert state.cleared, "Состояние должно очищаться после очистки очереди"
+    assert calls["sync"] == (77, []), "Очередь должна очищаться через warmclear"
+    assert calls["mode"] == (77, "standard", {"warmup_days": None})
+    assert calls["main_message"], "После очистки должно обновляться главное меню"
+    assert calls["messages"], "Пользователь должен получать уведомление"
+    assert callback.answered, "Коллбек должен подтверждаться"


### PR DESCRIPTION
## Summary
- add an inline Clear button to the warmup management prompt and handle warmclear callbacks to reset the queue
- update warmup messaging to reference the inline control and keep FSM state tidy
- cover the new warmup clear callback behavior with unit tests

## Testing
- pytest test_manage_warmup_channels.py

------
https://chatgpt.com/codex/tasks/task_e_68e0cf7bbdb48330af8bef999f3de9e0