### PR TITLE
Escape markdown in account summary rendering

### DIFF
--- a/main.py
+++ b/main.py
@@ -2062,14 +2062,22 @@ async def safe_send_comments(user_id, phone, account_id):
 
 async def format_channels_display(channels, title="Каналы", max_display=10):
     """Унифицированное отображение списка каналов"""
-    if not channels:
-        return f"{title}: нет"
+    sanitized_title = escape_markdown_text(str(title)) if title is not None else "Каналы"
 
-    if len(channels) <= max_display:
-        return f"{title} ({len(channels)}):\n" + '\n'.join(channels)
+    if not channels:
+        return f"{sanitized_title}: нет"
+
+    escaped_channels = [escape_markdown_text(str(channel)) for channel in channels]
+
+    if len(escaped_channels) <= max_display:
+        return f"{sanitized_title} ({len(escaped_channels)}):\n" + '\n'.join(escaped_channels)
     else:
-        displayed = channels[:max_display]
-        return f"{title} ({len(channels)}):\n" + '\n'.join(displayed) + f"\n... и еще {len(channels) - max_display} каналов"
+        displayed = escaped_channels[:max_display]
+        return (
+            f"{sanitized_title} ({len(escaped_channels)}):\n"
+            + '\n'.join(displayed)
+            + f"\n... и еще {len(escaped_channels) - max_display} каналов"
+        )
 
 
 def escape_markdown_text(text: str) -> str:
@@ -2113,7 +2121,13 @@ async def get_account_summary(account_id):
     account = await get_account_by_id(account_id)
     if not account:
         return None
-    
+
+    def sanitize_field(value, default="N/A"):
+        """Подготавливает значение для безопасного отображения в Markdown."""
+        if value is None or value == "":
+            value = default
+        return escape_markdown_text(str(value))
+
     # Получаем реальные подписки аккаунта из Telegram
     real_channels = []
     try:
@@ -2155,14 +2169,27 @@ async def get_account_summary(account_id):
         prompt_block = f"{notice}\n{escape_markdown_text(prompt_preview)}"
 
     # Формируем резюме
+    phone = sanitize_field(account.get('phone', 'N/A'))
+    sleep_min = sanitize_field(account.get('sleep_min', 'N/A'))
+    sleep_max = sanitize_field(account.get('sleep_max', 'N/A'))
+    chance = sanitize_field(account.get('chance', 'N/A'))
+    mode = sanitize_field(account.get('mode', 'N/A'))
+    status = sanitize_field(account.get('status', 'N/A'))
+    warmup_end_at = sanitize_field(account.get('warmup_end_at', 'N/A'))
+    warmup_joined_today = sanitize_field(account.get('warmup_joined_today', 0))
+    warmup_next_join_at = sanitize_field(account.get('warmup_next_join_at', 'N/A'))
+    last_started_at = sanitize_field(account.get('last_started_at', 'N/A'))
+    last_stopped_at = sanitize_field(account.get('last_stopped_at', 'N/A'))
+    updated_at = sanitize_field(account.get('updated_at', 'N/A'))
+
     summary = f"""
-📊 **Резюме аккаунта {account.get('phone', 'N/A')}**
+📊 **Резюме аккаунта {phone}**
 
 ⚙️ **Настройки:**
-• Задержка: {account.get('sleep_min', 'N/A')}-{account.get('sleep_max', 'N/A')} сек
-• Шанс комментирования: {account.get('chance', 'N/A')}%
-• Режим: {account.get('mode', 'N/A')}
-• Статус: {account.get('status', 'N/A')}
+• Задержка: {sleep_min}-{sleep_max} сек
+• Шанс комментирования: {chance}%
+• Режим: {mode}
+• Статус: {status}
 
 📝 **Системный промпт (превью):**
 {prompt_block}
@@ -2177,14 +2204,14 @@ async def get_account_summary(account_id):
 {await format_channels_display(warmup_list, "Прогрев", 10)}
 
 📅 **Время прогрева:**
-• Завершение: {account.get('warmup_end_at', 'N/A')}
-• Вступлений сегодня: {account.get('warmup_joined_today', 0)}
-• Следующее вступление: {account.get('warmup_next_join_at', 'N/A')}
+• Завершение: {warmup_end_at}
+• Вступлений сегодня: {warmup_joined_today}
+• Следующее вступление: {warmup_next_join_at}
 
 🕐 **Время работы:**
-• Запущен: {account.get('last_started_at', 'N/A')}
-• Остановлен: {account.get('last_stopped_at', 'N/A')}
-• Обновлен: {account.get('updated_at', 'N/A')}
+• Запущен: {last_started_at}
+• Остановлен: {last_stopped_at}
+• Обновлен: {updated_at}
 """
     return summary
 

--- a/test_get_account_summary.py
+++ b/test_get_account_summary.py
@@ -1,0 +1,54 @@
+import asyncio
+import os
+
+os.environ.setdefault("API_ID", "1")
+os.environ.setdefault("API_HASH", "hash")
+os.environ.setdefault("BOT_TOKEN", "123456:TEST")
+
+import main
+
+
+def test_get_account_summary_handles_markdown_special_chars(monkeypatch):
+    account_data = {
+        "phone": "+123_456*789",
+        "sleep_min": 5,
+        "sleep_max": 15,
+        "chance": 42,
+        "mode": "test_mode_with_*_char",
+        "status": "active_status_with_underscore",
+        "system_prompt": "Prompt with _star*",
+        "warmup_end_at": "2024-01-02 10:00_utc*",
+        "warmup_joined_today": 3,
+        "warmup_next_join_at": "2024-01-02 12:00",
+        "last_started_at": "2024-01-01 08:00",
+        "last_stopped_at": "2024-01-01 22:00",
+        "updated_at": "2024-01-01 23:59",
+        "channels": ["@db_channel_one", "@db*channel"],
+        "session_path": "",
+    }
+
+    warmup_channels = [
+        {"channel": "@warmup_channel*"},
+        {"channel": "@warmup_channel_two"},
+    ]
+
+    async def fake_get_account_by_id(account_id):
+        return account_data
+
+    async def fake_get_warmup_pending(account_id, limit=100):
+        return warmup_channels
+
+    monkeypatch.setattr(main, "get_account_by_id", fake_get_account_by_id)
+    monkeypatch.setattr(main, "get_warmup_pending", fake_get_warmup_pending)
+
+    summary = asyncio.run(main.get_account_summary(1))
+    assert summary is not None
+
+    assert "+123\\_456\\*789" in summary
+    assert "@db\\_channel\\_one" in summary
+    assert "@db\\*channel" in summary
+    assert "@warmup\\_channel\\*" in summary
+    assert "active\\_status\\_with\\_underscore" in summary
+    assert "2024-01-02 10:00\\_utc\\*" in summary
+    assert "Prompt with \\_star\\*" in summary
+    assert "Prompt with \\\\_star" not in summary


### PR DESCRIPTION
## Summary
- escape channel titles and entries before rendering Markdown channel lists
- sanitize dynamic account summary fields to avoid Markdown formatting issues
- add regression test covering account summary with channels containing special characters

## Testing
- pytest test_get_account_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d68657948330848baa5901b2de60