### PR TITLE
Handle locked DB when toggling account status

### DIFF
--- a/db.py
+++ b/db.py
@@ -707,7 +707,7 @@ async def mark_account_running(account_id: int) -> None:
         )
         await conn.commit()
 
-    await _retry_db_operation(_execute_update)
+    await _retry_db_operation(_execute_update, max_retries=5)
 
 
 async def mark_account_stopped(account_id: int) -> None:
@@ -725,7 +725,7 @@ async def mark_account_stopped(account_id: int) -> None:
         )
         await conn.commit()
 
-    await _retry_db_operation(_execute_update)
+    await _retry_db_operation(_execute_update, max_retries=5)
 
 
 async def delete_account(user_id: int, phone: str) -> None:

--- a/main.py
+++ b/main.py
@@ -1520,7 +1520,14 @@ async def send_comments(userid, session, account_id):
             key = make_session_key(userid, session)
             account_id = active_account_ids.pop(key, None)
             if account_id:
-                await mark_account_stopped(account_id)
+                try:
+                    await mark_account_stopped(account_id)
+                except sqlite3.OperationalError as db_exc:
+                    logging.error(
+                        "Failed to mark account %s stopped after retries: %s",
+                        account_id,
+                        db_exc,
+                    )
             active_sessions.pop(key, None)
             quiet_sessions_notified.discard(key)
             active_pyrogram_clients.pop(key, None)
@@ -2199,7 +2206,14 @@ async def safe_send_comments(user_id, phone, account_id):
     except Exception as e:
         logging.exception("Error in send_comments for account %s: %s", account_id, e)
         # Останавливаем аккаунт при критической ошибке
-        await mark_account_stopped(account_id)
+        try:
+            await mark_account_stopped(account_id)
+        except sqlite3.OperationalError as db_exc:
+            logging.error(
+                "Failed to mark account %s stopped after retries: %s",
+                account_id,
+                db_exc,
+            )
         key = make_session_key(user_id, phone)
         active_sessions.pop(key, None)
         active_account_ids.pop(key, None)


### PR DESCRIPTION
## Summary
- ensure account status updates retry through `_retry_db_operation` with an increased attempt limit
- log failures to persist stopped status when retries are exhausted during comment session cleanup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e17734e66483308ebcc54c024b96d7