### PR TITLE
Rearrange main menu keyboard layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -582,10 +582,10 @@ async def main_message(message):
     builder.row(
         types.InlineKeyboardButton(text="Добавить аккаунт", callback_data="add_account"),
         types.InlineKeyboardButton(text="Добавить прогрев", callback_data="add_warmup"),
-        types.InlineKeyboardButton(text="Настройки прогрева", callback_data="warmup_settings"),
     )
     builder.row(
-        types.InlineKeyboardButton(text="Общая статистика", callback_data="global_stats"),
+        types.InlineKeyboardButton(text="📊 Общая статистика", callback_data="global_stats"),
+        types.InlineKeyboardButton(text="⚙️ Настройки прогрева", callback_data="warmup_settings"),
     )
 
     await bot.send_message(message.from_user.id, 'Ваши аккаунты', reply_markup=builder.as_markup())

--- a/test_main_keyboard_layout.py
+++ b/test_main_keyboard_layout.py
@@ -1,0 +1,99 @@
+import os
+import types
+
+import pytest
+
+
+os.environ.setdefault("API_ID", "1")
+os.environ.setdefault("API_HASH", "hash")
+os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
+
+import main  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class DummyMessage:
+    def __init__(self, user_id: int) -> None:
+        self.from_user = types.SimpleNamespace(id=user_id)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_main_menu_keyboard_layout_no_accounts(monkeypatch):
+    user_id = 777
+    existing_dirs: set[str] = set()
+    existing_files: set[str] = set()
+
+    def _norm(path: str) -> str:
+        return os.path.normpath(path)
+
+    def fake_isdir(path: str) -> bool:
+        return _norm(path) in existing_dirs
+
+    def fake_makedirs(path: str, exist_ok: bool = False) -> None:  # noqa: ARG001
+        norm_path = _norm(path)
+        if norm_path in ("", "."):
+            return
+        parts = norm_path.split(os.sep)
+        cumulative = []
+        for part in parts:
+            cumulative.append(part)
+            existing_dirs.add(_norm(os.sep.join(cumulative)))
+
+    def fake_listdir(path: str) -> list[str]:  # noqa: ARG001
+        return []
+
+    def fake_exists(path: str) -> bool:
+        return _norm(path) in existing_files
+
+    async def fake_ensure_user(uid: int) -> None:  # noqa: ARG001
+        return None
+
+    async def fake_get_accounts(uid: int):  # noqa: ARG001
+        return []
+
+    async def fake_ensure_account(user_id: int, phone: str, session_path: str):  # noqa: ARG001
+        return None
+
+    sent: dict[str, object] = {}
+
+    async def fake_send_message(chat_id: int, text: str, reply_markup=None, **kwargs):  # noqa: ANN001
+        sent.update({
+            "chat_id": chat_id,
+            "text": text,
+            "markup": reply_markup,
+            "kwargs": kwargs,
+        })
+        return types.SimpleNamespace(message_id=1)
+
+    monkeypatch.setattr(main.os.path, "isdir", fake_isdir)
+    monkeypatch.setattr(main.os, "makedirs", fake_makedirs)
+    monkeypatch.setattr(main.os, "listdir", fake_listdir)
+    monkeypatch.setattr(main.os.path, "exists", fake_exists)
+    monkeypatch.setattr(main, "ensure_user", fake_ensure_user)
+    monkeypatch.setattr(main, "get_accounts_for_user", fake_get_accounts)
+    monkeypatch.setattr(main, "ensure_account", fake_ensure_account)
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+
+    await main.main_message(DummyMessage(user_id))
+
+    markup = sent.get("markup")
+    assert markup is not None, "Ожидается, что главное меню отправляется пользователю"
+
+    rows = markup.inline_keyboard
+    assert len(rows) == 2, "Без аккаунтов должно быть две строки действий"
+
+    add_row = rows[0]
+    assert [button.callback_data for button in add_row] == ["add_account", "add_warmup"], (
+        "Первый ряд должен содержать кнопки добавления аккаунта и прогрева"
+    )
+
+    bottom_row = rows[1]
+    assert [button.callback_data for button in bottom_row] == ["global_stats", "warmup_settings"], (
+        "Нижний ряд должен содержать сервисные кнопки статистики и настроек"
+    )
+    assert bottom_row[0].text == "📊 Общая статистика"
+    assert bottom_row[1].text == "⚙️ Настройки прогрева"


### PR DESCRIPTION
## Summary
- rearranged the main menu keyboard so account and warmup additions sit above the bottom service row
- highlighted the statistics and warmup settings buttons with icons for clarity
- added an async integration-style test covering the keyboard layout order

## Testing
- pytest test_main_keyboard_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68e17c2e7cbc833094ede8184ae174de