### PR TITLE
запущенная версия 04-10-25 Sync account channels after sleep setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1296,7 +1296,7 @@ async def add_systempromt(message: Message, state: FSMContext) -> None:
 
 @dp.message(startaccount.sleeps)
 async def add_sleeps(message: Message, state: FSMContext) -> None:
-    data, _, account = await _load_account_data(state)
+    data, account_id, account = await _load_account_data(state)
 
     stored_sleeps: Optional[str] = None
     if account:
@@ -1338,6 +1338,7 @@ async def add_sleeps(message: Message, state: FSMContext) -> None:
     session = data.get("account")
 
     channels: List[str] = []
+    seen_channels: Set[str] = set()
 
     app = Client(
         name=f"sessions/{message.from_user.id}/{session}",
@@ -1348,9 +1349,14 @@ async def add_sleeps(message: Message, state: FSMContext) -> None:
         async with app:
             async for dialog in app.get_dialogs():
                 chat = dialog.chat
-                if str(chat.type) == "ChatType.CHANNEL":
-                    if chat.username is not None:
-                        channels.append(f"@{chat.username}")
+                if str(chat.type) == "ChatType.CHANNEL" and chat.username is not None:
+                    channel_handle = f"@{chat.username}"
+                    if channel_handle not in seen_channels:
+                        channels.append(channel_handle)
+                        seen_channels.add(channel_handle)
+
+        if account_id:
+            await update_account_settings(account_id, channels=channels)
 
         # Используем унифицированное отображение каналов
         channels_display = await format_channels_display(
@@ -1985,11 +1991,15 @@ async def add_regular_channels(message: Message, state: FSMContext) -> None:
     system_prompt_value = data.get("systempromt") if data else None
     sleeps = data.get("sleeps") if data else None
 
-    existing_channels_raw = []
+    existing_channels_raw: List[str] = []
     if account and isinstance(account, dict):
         stored_channels = account.get("channels")
         if isinstance(stored_channels, list):
             existing_channels_raw = [channel for channel in stored_channels if isinstance(channel, str)]
+
+    existing_channels_lookup: Set[str] = {
+        channel.lower() for channel in existing_channels_raw if isinstance(channel, str)
+    }
 
     if not account_id:
         await bot.send_message(message.from_user.id, "Ошибка: аккаунт не найден. Попробуйте снова.")
@@ -2000,7 +2010,21 @@ async def add_regular_channels(message: Message, state: FSMContext) -> None:
     channels_to_update: Optional[List[str]] = None
     successful_channels: List[str] = []
     if str(message.text) != '-':
-        channels = [line.strip() for line in message.text.splitlines() if line.strip()]
+        raw_channels = [line.strip() for line in message.text.splitlines() if line.strip()]
+
+        channels: List[str] = []
+        seen_new: Set[str] = set()
+        for channel in raw_channels:
+            if channel.startswith("-"):
+                channels.append(channel)
+                continue
+
+            normalized = channel.lower()
+            if normalized in existing_channels_lookup or normalized in seen_new:
+                continue
+
+            seen_new.add(normalized)
+            channels.append(channel)
 
         # Вступаем в обычные каналы сразу
         for channel in channels:

--- a/test_manage_warmup_channels.py
+++ b/test_manage_warmup_channels.py
@@ -2,25 +2,33 @@ import asyncio
 import os
 import types
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 os.environ.setdefault("API_ID", "1")
 os.environ.setdefault("API_HASH", "test")
 os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
 
 import main
+import db
 
 
 class DummyState:
     def __init__(self, data: Dict[str, Any]):
         self._data = data
         self.cleared = False
+        self.state_value = None
 
     async def get_data(self) -> Dict[str, Any]:
         return self._data
 
+    async def update_data(self, updates: Dict[str, Any]) -> None:
+        self._data.update(updates)
+
     async def clear(self) -> None:
         self.cleared = True
+
+    async def set_state(self, value: Any) -> None:
+        self.state_value = value
 
 
 class DummyMessage:
@@ -85,7 +93,7 @@ def test_manage_warmup_channels_dash_keeps_queue_and_resets_schedule(monkeypatch
     async def fake_db_update(account_id: int, *, next_join=None, last_join=None):
         calls["db_update"] = {"account_id": account_id, "next_join": next_join, "last_join": last_join}
 
-    async def fake_format(channels, title="Каналы", max_display=10):
+    async def fake_format(channels, title="Каналы", max_display=10, **kwargs: Any):
         return f"{title}: {', '.join(channels)}" if channels else f"{title}: нет"
 
     async def fake_main_message(msg):
@@ -142,7 +150,7 @@ def test_manage_warmup_channels_clear_switches_to_standard(monkeypatch):
     async def fake_db_update(account_id: int, *, next_join=None, last_join=None):
         calls["db_update"] = True
 
-    async def fake_format(channels, title="Каналы", max_display=10):
+    async def fake_format(channels, title="Каналы", max_display=10, **kwargs: Any):
         return "Очередь: нет"
 
     async def fake_main_message(msg):
@@ -206,3 +214,87 @@ def test_warmclear_callback_clears_queue_and_state(monkeypatch):
     assert calls["main_message"], "После очистки должно обновляться главное меню"
     assert calls["messages"], "Пользователь должен получать уведомление"
     assert callback.answered, "Коллбек должен подтверждаться"
+
+
+def test_add_sleeps_syncs_subscriptions(monkeypatch, tmp_path):
+    db_path = tmp_path / "sleeps.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    asyncio.run(db.init_db())
+
+    user_id = 100
+    phone = "71234567890"
+    session_path = f"sessions/{user_id}/{phone}.session"
+
+    asyncio.run(db.ensure_user(user_id))
+    account = asyncio.run(db.ensure_account(user_id, phone, session_path))
+
+    state = DummyState({"account": phone, "account_id": account["id"]})
+    message = DummyMessage("10-20", user_id=user_id)
+
+    async def fake_check_account(user: int, session: str) -> bool:
+        assert user == user_id
+        assert session == phone
+        return True
+
+    class DummyChat:
+        def __init__(self, username: str | None):
+            self.username = username
+            self.type = "ChatType.CHANNEL"
+
+    class DummyDialog:
+        def __init__(self, chat: Any):
+            self.chat = chat
+
+    class DummyClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._dialogs = [
+                DummyDialog(DummyChat("alpha")),
+                DummyDialog(DummyChat("beta")),
+                DummyDialog(DummyChat("alpha")),
+                DummyDialog(DummyChat(None)),
+            ]
+
+        async def __aenter__(self) -> "DummyClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def get_dialogs(self):
+            for dialog in self._dialogs:
+                yield dialog
+
+    format_calls: List[List[str]] = []
+
+    async def fake_format(channels, title="Каналы", max_display=10, use_markdown=False):
+        format_calls.append(list(channels))
+        return f"{title}: {', '.join(channels)}"
+
+    sent_messages: List[tuple[int, str, Dict[str, Any]]] = []
+
+    async def fake_send_message(user: int, text: str, **kwargs: Any) -> None:
+        sent_messages.append((user, text, kwargs))
+
+    recorded_calls: List[Dict[str, Any]] = []
+
+    real_update = main.update_account_settings
+
+    async def tracking_update(account_id_arg: int, **kwargs: Any) -> None:
+        recorded_calls.append({"account_id": account_id_arg, **kwargs})
+        await real_update(account_id_arg, **kwargs)
+
+    monkeypatch.setattr(main, "check_account", fake_check_account)
+    monkeypatch.setattr(main, "Client", DummyClient)
+    monkeypatch.setattr(main, "format_channels_display", fake_format)
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+    monkeypatch.setattr(main, "update_account_settings", tracking_update)
+
+    asyncio.run(main.add_sleeps(message, state))
+
+    updated_account = asyncio.run(db.get_account_by_id(account["id"]))
+    assert updated_account is not None
+    assert recorded_calls == [{"account_id": account["id"], "channels": ["@alpha", "@beta"]}], (recorded_calls, format_calls, sent_messages)
+    assert format_calls == [["@alpha", "@beta"]], format_calls
+    assert updated_account["channels"] == ["@alpha", "@beta"], updated_account["channels"]
+
+    asyncio.run(db.close_db())


### PR DESCRIPTION
## Summary
- persist the current channel subscriptions when collecting dialogs during the sleep setup step and avoid duplicate regular channel joins
- extend the warmup channel tests with richer dummy state helpers and a regression test that confirms channel synchronization via get_account_by_id

## Testing
- pytest test_manage_warmup_channels.py

------
https://chatgpt.com/codex/tasks/task_e_68e17e46a6b88330933150327e0b3b1e