### PR TITLE
Cache OpenAI client in comment engine

### DIFF
--- a/comment_engine.py
+++ b/comment_engine.py
@@ -2,9 +2,12 @@
 from openai import OpenAI
 import os
 from dotenv import load_dotenv
+from typing import Optional
 
 load_dotenv()
 key = os.getenv('OPENAI_API_KEY')
+
+_client: Optional[OpenAI] = None
 
 
 def build_prompt(post_text: str, system_prompt) -> list:
@@ -13,16 +16,28 @@ def build_prompt(post_text: str, system_prompt) -> list:
         {"role": "user", "content": f"Пост: {post_text}\nКомментарий:"}
     ]
 
+
+def _get_client() -> OpenAI:
+    global _client
+
+    if _client is None:
+        if not key:
+            raise RuntimeError("OPENAI_API_KEY is not set")
+
+        _client = OpenAI(api_key=key)
+
+    return _client
+
+
 def generate_comment(post_text: str, system_prompt) -> str:
     messages = build_prompt(post_text, system_prompt)
     try:
-
-        client = OpenAI(api_key=key)
-
-
+        client = _get_client()
         response = client.responses.create(model='gpt-4o', input=messages)
-
         return response.output_text
+    except RuntimeError as e:
+        print(f"[ERROR] OpenAI configuration error: {e}")
+        return ""
     except Exception as e:
         print(f"[ERROR] OpenAI error: {e}")
         return ""

--- a/test_comment_engine.py
+++ b/test_comment_engine.py
@@ -1,0 +1,47 @@
+import types
+
+import comment_engine
+
+
+def test_generate_comment_reuses_cached_client(monkeypatch):
+    calls = []
+
+    class DummyResponses:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            return types.SimpleNamespace(output_text="dummy-comment")
+
+    class DummyClient:
+        instances = 0
+
+        def __init__(self, api_key):
+            DummyClient.instances += 1
+            self.api_key = api_key
+            self.responses = DummyResponses()
+
+    monkeypatch.setattr(comment_engine, "OpenAI", DummyClient)
+    monkeypatch.setattr(comment_engine, "key", "test-key")
+    monkeypatch.setattr(comment_engine, "_client", None)
+
+    first = comment_engine.generate_comment("post", "system")
+    second = comment_engine.generate_comment("post-2", "system-2")
+
+    assert first == "dummy-comment"
+    assert second == "dummy-comment"
+    assert DummyClient.instances == 1
+    assert len(calls) == 2
+
+
+def test_generate_comment_without_api_key(monkeypatch, capsys):
+    def fail_openai(*args, **kwargs):
+        raise AssertionError("OpenAI should not be instantiated when key is missing")
+
+    monkeypatch.setattr(comment_engine, "OpenAI", fail_openai)
+    monkeypatch.setattr(comment_engine, "key", None)
+    monkeypatch.setattr(comment_engine, "_client", None)
+
+    result = comment_engine.generate_comment("post", "system")
+
+    assert result == ""
+    captured = capsys.readouterr()
+    assert "OPENAI_API_KEY" in captured.out


### PR DESCRIPTION
## Summary
- cache the OpenAI client so it is created only once
- handle missing API keys before attempting to create the client
- add tests covering client reuse and missing key behaviour

## Testing
- pytest test_comment_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68e19e2b0f948330aa70b484a0329088