### PR TITLE
Add reaction metrics to global statistics report

### DIFF
--- a/db.py
+++ b/db.py
@@ -878,6 +878,13 @@ async def get_global_statistics() -> Dict[str, Any]:
     )
     comments_total = sum(comment_counts.values())
 
+    reaction_counts = {
+        status[len("reaction_") :]: count
+        for status, count in comment_counts.items()
+        if status.startswith("reaction_")
+    }
+    reaction_total = sum(reaction_counts.values())
+
     warmup_counts = await _fetch_counts(
         "SELECT status, COUNT(*) FROM warmup_channels GROUP BY status"
     )
@@ -898,6 +905,8 @@ async def get_global_statistics() -> Dict[str, Any]:
         "comments": {
             "total": comments_total,
             "by_status": comment_counts,
+            "reactions": reaction_counts,
+            "reactions_total": reaction_total,
         },
         "warmup": {
             "by_status": warmup_counts,

--- a/main.py
+++ b/main.py
@@ -2838,6 +2838,8 @@ def format_global_statistics_report(stats: Dict[str, Any]) -> str:
 
     comment_counts = comments.get("by_status", {})
     warmup_counts = warmup.get("by_status", {})
+    reaction_counts = comments.get("reactions", {})
+    reaction_total = comments.get("reactions_total", 0)
 
     def _format_additional(counts: Dict[str, Any], known_keys: Set[str]) -> Optional[str]:
         extra = [f"{key}: {counts[key]}" for key in sorted(counts) if key not in known_keys]
@@ -2885,6 +2887,23 @@ def format_global_statistics_report(stats: Dict[str, Any]) -> str:
     )
     if other_comment_statuses:
         lines.append(f"• Прочие статусы: {other_comment_statuses}")
+
+    lines.extend(
+        [
+            "",
+            "😊 *Реакции*",
+            f"• Всего: {reaction_total}",
+            f"• Успешные: {reaction_counts.get('success', 0)}",
+            f"• Ошибки: {reaction_counts.get('error', 0)}",
+            f"• Пропущено: {reaction_counts.get('skipped', 0)}",
+        ]
+    )
+
+    other_reaction_statuses = _format_additional(
+        reaction_counts, {"success", "error", "skipped"}
+    )
+    if other_reaction_statuses:
+        lines.append(f"• Прочие статусы: {other_reaction_statuses}")
 
     lines.extend(
         [

--- a/test_bot.py
+++ b/test_bot.py
@@ -61,6 +61,9 @@ async def test_get_global_statistics_and_report(tmp_path, monkeypatch):
     await db_module.add_comment_log(account1["id"], channel="chat", message_id=2, status="error", error="boom")
     await db_module.add_comment_log(account2["id"], channel="chat", message_id=3, status="skipped", error="rnd")
     await db_module.add_comment_log(account2["id"], channel="chat", message_id=4, status="no_comments", error="forbidden")
+    await db_module.add_comment_log(account2["id"], channel="chat", message_id=5, status="reaction_success")
+    await db_module.add_comment_log(account2["id"], channel="chat", message_id=6, status="reaction_error")
+    await db_module.add_comment_log(account3["id"], channel="chat", message_id=7, status="reaction_skipped")
 
     await db_module.sync_warmup_channels(account1["id"], ["@one", "@two"])
     await db_module.mark_warmup_channel_joined(account1["id"], "@one")
@@ -76,11 +79,15 @@ async def test_get_global_statistics_and_report(tmp_path, monkeypatch):
     assert stats["accounts"]["running_by_mode"].get("warmup") == 1
     assert stats["accounts"]["running_by_mode"].get("standard") == 1
 
-    assert stats["comments"]["total"] == 4
+    assert stats["comments"]["total"] == 7
     assert stats["comments"]["by_status"].get("success") == 1
     assert stats["comments"]["by_status"].get("error") == 1
     assert stats["comments"]["by_status"].get("skipped") == 1
     assert stats["comments"]["by_status"].get("no_comments") == 1
+    assert stats["comments"]["reactions_total"] == 3
+    assert stats["comments"]["reactions"].get("success") == 1
+    assert stats["comments"]["reactions"].get("error") == 1
+    assert stats["comments"]["reactions"].get("skipped") == 1
 
     assert stats["warmup"]["by_status"].get("joined") == 1
     assert stats["warmup"]["by_status"].get("error") == 1
@@ -100,6 +107,8 @@ async def test_get_global_statistics_and_report(tmp_path, monkeypatch):
     assert "Нет ветки/запрещено: 1" in report
     assert "Прогрев" in report
     assert "Попыток вступления: 1" in report
+    assert "😊 *Реакции*" in report
+    assert "😊 *Реакции*\n• Всего: 3" in report
 
     await db_module.close_db()
 


### PR DESCRIPTION
## Summary
- track reaction-specific counts alongside comment statistics in the database aggregation
- surface reaction totals and breakdown in the global statistics report sent to the log channel
- cover the new reaction metrics in the global statistics report test

## Testing
- pytest test_bot.py::test_get_global_statistics_and_report

------
https://chatgpt.com/codex/tasks/task_e_68e19f17ea848330bec69dce5b0cdeea