### PR TITLE
Add last reaction tracking and cooldown handling

### DIFF
--- a/db.py
+++ b/db.py
@@ -196,6 +196,7 @@ async def init_db() -> None:
     await _ensure_column("accounts", "reaction_sleep_min", "INTEGER")
     await _ensure_column("accounts", "reaction_sleep_max", "INTEGER")
     await _ensure_column("accounts", "reaction_limit_per_message", "INTEGER")
+    await _ensure_column("accounts", "last_reaction_at", "TEXT")
 
     await conn.commit()
     _CONN = conn
@@ -454,6 +455,7 @@ async def update_account_settings(
     reaction_sleep_max: Optional[int] = None,
     reaction_emojis: Optional[List[str]] = None,
     reaction_limit_per_message: Any = _UNSET,
+    last_reaction_at: Any = _UNSET,
     channels: Optional[List[str]] = None,
 ) -> None:
     print(
@@ -492,6 +494,12 @@ async def update_account_settings(
     if reaction_limit_per_message is not _UNSET:
         updates.append("reaction_limit_per_message = ?")
         values.append(reaction_limit_per_message)
+    if last_reaction_at is not _UNSET:
+        updates.append("last_reaction_at = ?")
+        if isinstance(last_reaction_at, datetime):
+            values.append(last_reaction_at.isoformat())
+        else:
+            values.append(last_reaction_at)
     if channels is not None:
         updates.append("channels = ?")
         values.append(_serialize_list(channels))
@@ -556,6 +564,20 @@ async def bulk_update_reaction_settings(
     """
 
     await conn.execute(query, tuple(values))
+    await conn.commit()
+
+
+async def update_last_reaction_at(account_id: int, timestamp: Optional[datetime]) -> None:
+    conn = await _require_conn()
+    value = timestamp.isoformat() if timestamp is not None else None
+    await conn.execute(
+        """
+        UPDATE accounts
+        SET last_reaction_at = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+        """,
+        (value, account_id),
+    )
     await conn.commit()
 
 

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ from db import (
     set_user_authenticated,
     sync_warmup_channels,
     update_account_settings,
+    update_last_reaction_at,
     update_warmup_settings,
     _require_pool,
 )
@@ -109,6 +110,7 @@ WARMUP_VERBOSE_LOGS = _get_bool_env("WARMUP_VERBOSE_LOGS", default=False)
 WARMUP_VERBOSE_NOTIFICATIONS = _get_bool_env("WARMUP_VERBOSE_NOTIFICATIONS", default=False)
 
 DEFAULT_REACTION_LIMIT_PER_MESSAGE = _get_int_env("REACTION_LIMIT_PER_MESSAGE")
+REACTION_MIN_INTERVAL_SECONDS = _get_int_env("REACTION_MIN_INTERVAL_SECONDS") or 0
 
 # Инициализация бота
 bot = Bot(token=BOT_TOKEN)
@@ -235,15 +237,18 @@ async def _handle_linked_channel_message(
     reaction_sleep_min: int,
     reaction_sleep_max: int,
     reaction_limit_per_message: Optional[int],
-) -> None:
+    last_reaction_at: Optional[datetime] = None,
+) -> Optional[datetime]:
     key = make_session_key(userid, session)
     if not active_sessions.get(key, False):
-        return
+        return last_reaction_at
+
+    current_last_reaction_at = last_reaction_at
 
     is_discussion_message = _is_discussion_reply_message(message)
     if is_discussion_message and _is_self_generated_message(message):
         logging.debug("Обнаружен собственный комментарий в обсуждении для %s", session)
-        return
+        return current_last_reaction_at
 
     post_text = _extract_post_text(message)
     if post_text is None:
@@ -254,7 +259,7 @@ async def _handle_linked_channel_message(
             status='no_comments',
             error='no text or caption',
         )
-        return
+        return current_last_reaction_at
 
     can_send, reason = _chat_allows_sending_message(message)
     if not can_send:
@@ -265,7 +270,7 @@ async def _handle_linked_channel_message(
             status='no_comments',
             error=reason or 'comments disabled',
         )
-        return
+        return current_last_reaction_at
 
     try:
         roll = random.randint(1, 100)
@@ -278,7 +283,7 @@ async def _handle_linked_channel_message(
                 status='skipped',
                 error=f'random {roll} > chance {chance}',
             )
-            return
+            return current_last_reaction_at
 
         if is_quiet_period():
             if key not in quiet_sessions_notified:
@@ -287,7 +292,7 @@ async def _handle_linked_channel_message(
                     f'Аккаунт {session} приостановлен до {QUIET_END_MSK_STR} МСК (циркадный режим)'
                 )
                 quiet_sessions_notified.add(key)
-            return
+            return current_last_reaction_at
 
         await asyncio.sleep(random.uniform(xsleep, ysleep))
         comment = generate_comment(post_text, system_promt)
@@ -323,7 +328,7 @@ async def _handle_linked_channel_message(
                         status='reaction_skipped',
                         error=f'reaction limit {limit} reached',
                     )
-                    return
+                    return current_last_reaction_at
                 if channel_for_reactions and message_id is not None:
                     reaction_count = await count_reactions_for_message(channel_for_reactions, message_id)
                     if reaction_count >= limit:
@@ -335,18 +340,40 @@ async def _handle_linked_channel_message(
                             status='reaction_skipped',
                             error=f'reaction limit {reaction_count}/{limit}',
                         )
-                        return
+                        return current_last_reaction_at
 
             reaction_roll = random.randint(1, 100)
             if reaction_roll <= reaction_chance:
                 await asyncio.sleep(random.uniform(reaction_sleep_min, reaction_sleep_max))
                 reaction_emoji = random.choice(reaction_emojis)
                 try:
+                    now = datetime.now(timezone.utc)
+                    previous = current_last_reaction_at
+                    if previous is not None and previous.tzinfo is None:
+                        previous = previous.replace(tzinfo=timezone.utc)
+                    cooldown_seconds = REACTION_MIN_INTERVAL_SECONDS
+                    if previous is not None and cooldown_seconds:
+                        if now - previous < timedelta(seconds=cooldown_seconds):
+                            await asyncio.sleep(0.2)
+                            await add_comment_log(
+                                account_id,
+                                channel=str(message.chat.id),
+                                message_id=message.id,
+                                status='reaction_skipped',
+                                error=(
+                                    'reaction cooldown '
+                                    f"{int((now - previous).total_seconds())}/{cooldown_seconds}s"
+                                ),
+                            )
+                            return current_last_reaction_at
+
                     await client.send_reaction(message.chat.id, message.id, reaction_emoji)
                     await bot.send_message(
                         log_channel,
                         f'Аккаунт {session} поставил реакцию {reaction_emoji}\n{post_base_link}'
                     )
+                    await update_last_reaction_at(account_id, now)
+                    current_last_reaction_at = now
                     await asyncio.sleep(0.2)
                     await add_comment_log(
                         account_id,
@@ -398,6 +425,8 @@ async def _handle_linked_channel_message(
             status='error',
             error=str(e),
         )
+
+    return current_last_reaction_at
 
 
 class TransientJoinError(Exception):
@@ -2152,6 +2181,17 @@ async def send_comments(userid, session, account_id):
         if reaction_sleep_min > reaction_sleep_max:
             reaction_sleep_min, reaction_sleep_max = reaction_sleep_max, reaction_sleep_min
 
+        last_reaction_at_str = account.get("last_reaction_at")
+        last_reaction_at_dt: Optional[datetime] = None
+        if last_reaction_at_str:
+            try:
+                parsed = datetime.fromisoformat(last_reaction_at_str)
+            except ValueError:
+                parsed = None
+            if parsed is not None and parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            last_reaction_at_dt = parsed
+
         @app.on_message(filters.channel)
         async def channel_handler(client: Client, message: Message):
             key = make_session_key(userid, session)
@@ -2172,7 +2212,8 @@ async def send_comments(userid, session, account_id):
 
         @app.on_message(filters.linked_channel | discussion_filter)
         async def linked_channel_handler(client: Client, message: Message):
-            await _handle_linked_channel_message(
+            nonlocal last_reaction_at_dt
+            last_reaction_at_dt = await _handle_linked_channel_message(
                 client,
                 message,
                 userid=userid,
@@ -2187,6 +2228,7 @@ async def send_comments(userid, session, account_id):
                 reaction_sleep_min=reaction_sleep_min,
                 reaction_sleep_max=reaction_sleep_max,
                 reaction_limit_per_message=reaction_limit_per_message,
+                last_reaction_at=last_reaction_at_dt,
             )
         try:
             await app.start()

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -1,5 +1,6 @@
 import os
 import types
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -87,6 +88,12 @@ async def test_discussion_reply_from_user_triggers_comment_and_reaction(monkeypa
     def fake_uniform(a, b):
         return 0
 
+    updated_reactions = []
+
+    async def fake_update_last_reaction_at(account, ts):
+        updated_reactions.append((account, ts))
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
     monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
     monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
     monkeypatch.setattr(main, "generate_comment", fake_generate_comment)
@@ -95,6 +102,7 @@ async def test_discussion_reply_from_user_triggers_comment_and_reaction(monkeypa
     monkeypatch.setattr(main.random, "randint", fake_randint)
     monkeypatch.setattr(main.random, "uniform", fake_uniform)
     monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
 
     try:
         await main._handle_linked_channel_message(
@@ -112,6 +120,7 @@ async def test_discussion_reply_from_user_triggers_comment_and_reaction(monkeypa
             reaction_sleep_min=0,
             reaction_sleep_max=0,
             reaction_limit_per_message=5,
+            last_reaction_at=None,
         )
     finally:
         main.active_sessions.clear()
@@ -125,6 +134,7 @@ async def test_discussion_reply_from_user_triggers_comment_and_reaction(monkeypa
     statuses = {kwargs.get("status") for _, kwargs in comment_logs}
     assert "success" in statuses
     assert "reaction_success" in statuses
+    assert len(updated_reactions) == 1
 
 
 @pytest.mark.anyio
@@ -182,6 +192,7 @@ async def test_reaction_skipped_when_limit_reached(monkeypatch):
     def fake_uniform(a, b):
         return 0
 
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
     monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
     monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
     monkeypatch.setattr(main, "generate_comment", fake_generate_comment)
@@ -190,6 +201,7 @@ async def test_reaction_skipped_when_limit_reached(monkeypatch):
     monkeypatch.setattr(main.random, "randint", fake_randint)
     monkeypatch.setattr(main.random, "uniform", fake_uniform)
     monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_sleep)
 
     try:
         await main._handle_linked_channel_message(
@@ -207,6 +219,7 @@ async def test_reaction_skipped_when_limit_reached(monkeypatch):
             reaction_sleep_min=0,
             reaction_sleep_max=0,
             reaction_limit_per_message=5,
+            last_reaction_at=None,
         )
     finally:
         main.active_sessions.clear()
@@ -220,3 +233,218 @@ async def test_reaction_skipped_when_limit_reached(monkeypatch):
     assert "success" in statuses
     assert "reaction_skipped" in statuses
     assert all(status != "reaction_success" for status in statuses if status is not None)
+
+
+@pytest.mark.anyio
+async def test_reaction_skipped_when_cooldown_active(monkeypatch):
+    userid = 123
+    session = "+100500"
+    account_id = 42
+
+    original_active_sessions = dict(main.active_sessions)
+    original_quiet = set(main.quiet_sessions_notified)
+
+    main.active_sessions.clear()
+    main.quiet_sessions_notified.clear()
+    key = main.make_session_key(userid, session)
+    main.active_sessions[key] = True
+
+    client = DummyClient()
+
+    chat = types.SimpleNamespace(id=-2000000000, permissions=None, type="supergroup")
+    reply_to_message = types.SimpleNamespace(
+        forward_from_chat=types.SimpleNamespace(username="source_channel"),
+        forward_from_message_id=321,
+    )
+    from_user = types.SimpleNamespace(is_self=False)
+    message = types.SimpleNamespace(
+        chat=chat,
+        text="Original post",
+        caption=None,
+        id=111,
+        reply_to_message=reply_to_message,
+        from_user=from_user,
+    )
+
+    bot_logs = []
+    comment_logs = []
+
+    async def fake_bot_send_message(chat_id, text):
+        bot_logs.append((chat_id, text))
+
+    async def fake_add_comment_log(*args, **kwargs):
+        comment_logs.append((args, kwargs))
+
+    def fake_generate_comment(post_text, system_prompt):
+        return f"comment:{post_text}:{system_prompt}"
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    async def fake_count_reactions(*args, **kwargs):
+        return 0
+
+    def fake_randint(a, b):
+        return 1
+
+    def fake_uniform(a, b):
+        return 0
+
+    updated_reactions: list[tuple[int, datetime]] = []
+
+    async def fake_update_last_reaction_at(account, ts):
+        updated_reactions.append((account, ts))
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 60)
+    monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
+    monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
+    monkeypatch.setattr(main, "generate_comment", fake_generate_comment)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "count_reactions_for_message", fake_count_reactions)
+    monkeypatch.setattr(main.random, "randint", fake_randint)
+    monkeypatch.setattr(main.random, "uniform", fake_uniform)
+    monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
+
+    recent_reaction = datetime.now(timezone.utc)
+
+    try:
+        result = await main._handle_linked_channel_message(
+            client,
+            message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=100,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥"],
+            reaction_chance=100,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=5,
+            last_reaction_at=recent_reaction,
+        )
+    finally:
+        main.active_sessions.clear()
+        main.active_sessions.update(original_active_sessions)
+        main.quiet_sessions_notified.clear()
+        main.quiet_sessions_notified.update(original_quiet)
+
+    assert result == recent_reaction
+    assert not client.sent_reactions
+    statuses = [kwargs.get("status") for _, kwargs in comment_logs]
+    assert statuses.count("reaction_skipped") >= 1
+    cooldown_errors = [
+        kwargs.get("error")
+        for _, kwargs in comment_logs
+        if kwargs.get("status") == "reaction_skipped"
+    ]
+    assert any("cooldown" in (err or "") for err in cooldown_errors)
+    assert not updated_reactions
+
+
+@pytest.mark.anyio
+async def test_reaction_occurs_after_cooldown(monkeypatch):
+    userid = 123
+    session = "+100500"
+    account_id = 42
+
+    original_active_sessions = dict(main.active_sessions)
+    original_quiet = set(main.quiet_sessions_notified)
+
+    main.active_sessions.clear()
+    main.quiet_sessions_notified.clear()
+    key = main.make_session_key(userid, session)
+    main.active_sessions[key] = True
+
+    client = DummyClient()
+
+    chat = types.SimpleNamespace(id=-2000000000, permissions=None, type="supergroup")
+    reply_to_message = types.SimpleNamespace(
+        forward_from_chat=types.SimpleNamespace(username="source_channel"),
+        forward_from_message_id=321,
+    )
+    from_user = types.SimpleNamespace(is_self=False)
+    message = types.SimpleNamespace(
+        chat=chat,
+        text="Original post",
+        caption=None,
+        id=111,
+        reply_to_message=reply_to_message,
+        from_user=from_user,
+    )
+
+    bot_logs = []
+    comment_logs = []
+
+    async def fake_bot_send_message(chat_id, text):
+        bot_logs.append((chat_id, text))
+
+    async def fake_add_comment_log(*args, **kwargs):
+        comment_logs.append((args, kwargs))
+
+    def fake_generate_comment(post_text, system_prompt):
+        return f"comment:{post_text}:{system_prompt}"
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    async def fake_count_reactions(*args, **kwargs):
+        return 0
+
+    def fake_randint(a, b):
+        return 1
+
+    def fake_uniform(a, b):
+        return 0
+
+    updated_reactions: list[tuple[int, datetime]] = []
+
+    async def fake_update_last_reaction_at(account, ts):
+        updated_reactions.append((account, ts))
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 60)
+    monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
+    monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
+    monkeypatch.setattr(main, "generate_comment", fake_generate_comment)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "count_reactions_for_message", fake_count_reactions)
+    monkeypatch.setattr(main.random, "randint", fake_randint)
+    monkeypatch.setattr(main.random, "uniform", fake_uniform)
+    monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
+
+    previous_reaction = datetime.now(timezone.utc) - timedelta(seconds=120)
+
+    try:
+        result = await main._handle_linked_channel_message(
+            client,
+            message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=100,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥"],
+            reaction_chance=100,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=5,
+            last_reaction_at=previous_reaction,
+        )
+    finally:
+        main.active_sessions.clear()
+        main.active_sessions.update(original_active_sessions)
+        main.quiet_sessions_notified.clear()
+        main.quiet_sessions_notified.update(original_quiet)
+
+    assert client.sent_reactions
+    statuses = {kwargs.get("status") for _, kwargs in comment_logs}
+    assert "reaction_success" in statuses
+    assert updated_reactions
+    assert result is not None
+    assert result > previous_reaction


### PR DESCRIPTION
## Summary
- add a last_reaction_at column and helper functions to persist reaction timestamps
- enforce a configurable reaction cooldown before sending reactions and update the timestamp after success
- extend linked discussion handler tests to cover cooldown skip and success scenarios

## Testing
- pytest test_linked_discussion_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68e1facac3fc83308f1c6046f7aab491