### PR TITLE
Add separate reaction chance for discussion messages

### DIFF
--- a/db.py
+++ b/db.py
@@ -107,6 +107,7 @@ async def init_db() -> None:
             sleep_max INTEGER,
             reaction_emojis TEXT,
             reaction_chance INTEGER,
+            reaction_discussion_chance INTEGER,
             reaction_sleep_min INTEGER,
             reaction_sleep_max INTEGER,
             channels TEXT,
@@ -193,6 +194,7 @@ async def init_db() -> None:
 
     await _ensure_column("accounts", "reaction_emojis", "TEXT")
     await _ensure_column("accounts", "reaction_chance", "INTEGER")
+    await _ensure_column("accounts", "reaction_discussion_chance", "INTEGER")
     await _ensure_column("accounts", "reaction_sleep_min", "INTEGER")
     await _ensure_column("accounts", "reaction_sleep_max", "INTEGER")
     await _ensure_column("accounts", "reaction_limit_per_message", "INTEGER")
@@ -451,6 +453,7 @@ async def update_account_settings(
     sleep_min: Optional[int] = None,
     sleep_max: Optional[int] = None,
     reaction_chance: Optional[int] = None,
+    reaction_discussion_chance: Optional[int] = None,
     reaction_sleep_min: Optional[int] = None,
     reaction_sleep_max: Optional[int] = None,
     reaction_emojis: Optional[List[str]] = None,
@@ -482,6 +485,9 @@ async def update_account_settings(
     if reaction_chance is not None:
         updates.append("reaction_chance = ?")
         values.append(reaction_chance)
+    if reaction_discussion_chance is not None:
+        updates.append("reaction_discussion_chance = ?")
+        values.append(reaction_discussion_chance)
     if reaction_sleep_min is not None:
         updates.append("reaction_sleep_min = ?")
         values.append(reaction_sleep_min)
@@ -526,6 +532,7 @@ async def bulk_update_reaction_settings(
     user_id: int,
     *,
     reaction_chance: Optional[int] = None,
+    reaction_discussion_chance: Optional[int] = None,
     reaction_sleep_min: Optional[int] = None,
     reaction_sleep_max: Optional[int] = None,
     reaction_emojis: Optional[List[str]] = None,
@@ -537,6 +544,9 @@ async def bulk_update_reaction_settings(
     if reaction_chance is not None:
         updates.append("reaction_chance = ?")
         values.append(reaction_chance)
+    if reaction_discussion_chance is not None:
+        updates.append("reaction_discussion_chance = ?")
+        values.append(reaction_discussion_chance)
     if reaction_sleep_min is not None:
         updates.append("reaction_sleep_min = ?")
         values.append(reaction_sleep_min)

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, time, timezone, timedelta
 from typing import Dict, List, Optional, Set, Any, Union, Tuple
 import random
+import re
 from pyrogram import Client, filters
 from pyrogram.errors import ChatWriteForbidden, UserAlreadyParticipant
 from aiogram import Bot, Dispatcher, types
@@ -234,6 +235,7 @@ async def _handle_linked_channel_message(
     system_promt: str,
     reaction_emojis: List[str],
     reaction_chance: int,
+    reaction_discussion_chance: int,
     reaction_sleep_min: int,
     reaction_sleep_max: int,
     reaction_limit_per_message: Optional[int],
@@ -249,6 +251,10 @@ async def _handle_linked_channel_message(
     if is_discussion_message and _is_self_generated_message(message):
         logging.debug("Обнаружен собственный комментарий в обсуждении для %s", session)
         return current_last_reaction_at
+
+    selected_reaction_chance = (
+        reaction_discussion_chance if is_discussion_message else reaction_chance
+    )
 
     post_text = _extract_post_text(message)
     if post_text is None:
@@ -313,7 +319,7 @@ async def _handle_linked_channel_message(
             status='success',
         )
 
-        if reaction_emojis and reaction_chance > 0:
+        if reaction_emojis and selected_reaction_chance > 0:
             channel_for_reactions = str(getattr(getattr(message, "chat", None), "id", ""))
             message_id = getattr(message, "id", None)
             limit = reaction_limit_per_message
@@ -343,7 +349,7 @@ async def _handle_linked_channel_message(
                         return current_last_reaction_at
 
             reaction_roll = random.randint(1, 100)
-            if reaction_roll <= reaction_chance:
+            if reaction_roll <= selected_reaction_chance:
                 await asyncio.sleep(random.uniform(reaction_sleep_min, reaction_sleep_max))
                 reaction_emoji = random.choice(reaction_emojis)
                 try:
@@ -401,7 +407,7 @@ async def _handle_linked_channel_message(
                     channel=str(message.chat.id),
                     message_id=message.id,
                     status='reaction_skipped',
-                    error=f'reaction random {reaction_roll} > chance {reaction_chance}',
+                    error=f'reaction random {reaction_roll} > chance {selected_reaction_chance}',
                 )
 
     except ChatWriteForbidden as e:
@@ -1538,12 +1544,21 @@ async def _prompt_reaction_chance(message: Message, state: FSMContext) -> None:
     if stored is None:
         stored = data.get("reaction_chance")
 
+    stored_discussion = account.get("reaction_discussion_chance") if account else None
+    if stored_discussion is None:
+        stored_discussion = data.get("reaction_discussion_chance")
+    if stored_discussion is None:
+        stored_discussion = stored
+
     display = _format_chance(stored)
+    discussion_display = _format_chance(stored_discussion)
     await bot.send_message(
         message.from_user.id,
         (
             f"Текущий шанс реакции: {display}.\n"
-            "Отправьте значение от 0 до 100 или '-' для сохранения текущего."
+            f"Шанс реакции в обсуждениях: {discussion_display}.\n"
+            "Отправьте одно число (для обоих значений) или два числа через '/' или пробел "
+            "(сначала для постов, затем для обсуждений). Используйте '-' для сохранения текущих."
         ),
     )
 
@@ -1722,6 +1737,14 @@ async def add_reaction_chance(message: Message, state: FSMContext) -> None:
     if stored_chance is None:
         stored_chance = data.get("reaction_chance")
 
+    stored_discussion: Optional[Union[int, str]] = None
+    if account:
+        stored_discussion = account.get("reaction_discussion_chance")
+    if stored_discussion is None:
+        stored_discussion = data.get("reaction_discussion_chance")
+    if stored_discussion is None:
+        stored_discussion = stored_chance
+
     incoming = (message.text or "").strip()
 
     if incoming == "-":
@@ -1734,35 +1757,58 @@ async def add_reaction_chance(message: Message, state: FSMContext) -> None:
             return
         try:
             reaction_chance_value = int(stored_chance)
+            reaction_discussion_value = int(
+                stored_discussion if stored_discussion is not None else stored_chance
+            )
         except (TypeError, ValueError):
             await bot.send_message(
                 message.from_user.id,
-                "Не удалось определить сохранённый шанс реакции. Введите значение от 0 до 100.",
-            )
-            await _prompt_reaction_chance(message, state)
-            return
-    elif incoming.isdigit():
-        reaction_chance_value = int(incoming)
-        if reaction_chance_value < 0 or reaction_chance_value > 100:
-            await bot.send_message(
-                message.from_user.id,
-                "Шанс реакции должен быть в диапазоне от 0 до 100.",
+                (
+                    "Не удалось определить сохранённые значения шансов. "
+                    "Укажите одно число от 0 до 100 или два числа через '/' или пробел."
+                ),
             )
             await _prompt_reaction_chance(message, state)
             return
     else:
-        current_display = _format_chance(stored_chance)
-        await bot.send_message(
-            message.from_user.id,
-            (
-                f"Некорректное значение. Текущий шанс реакции: {current_display}.\n"
-                "Отправьте число от 0 до 100 или '-' для сохранения текущего."
-            ),
-        )
-        await _prompt_reaction_chance(message, state)
-        return
+        parts = [part for part in re.split(r"[\s,\/]+", incoming) if part]
 
-    await state.update_data({"reaction_chance": reaction_chance_value})
+        def _parse_part(part: str) -> int:
+            value = int(part)
+            if value < 0 or value > 100:
+                raise ValueError
+            return value
+
+        try:
+            if len(parts) == 1:
+                reaction_chance_value = _parse_part(parts[0])
+                reaction_discussion_value = reaction_chance_value
+            elif len(parts) == 2:
+                reaction_chance_value = _parse_part(parts[0])
+                reaction_discussion_value = _parse_part(parts[1])
+            else:
+                raise ValueError
+        except (ValueError, TypeError):
+            current_display = _format_chance(stored_chance)
+            discussion_display = _format_chance(stored_discussion)
+            await bot.send_message(
+                message.from_user.id,
+                (
+                    f"Некорректное значение. Текущий шанс реакции: {current_display}.\n"
+                    f"Шанс в обсуждениях: {discussion_display}.\n"
+                    "Отправьте одно число от 0 до 100 или два числа через '/' или пробел "
+                    "(сначала для постов, затем для обсуждений)."
+                ),
+            )
+            await _prompt_reaction_chance(message, state)
+            return
+
+    await state.update_data(
+        {
+            "reaction_chance": reaction_chance_value,
+            "reaction_discussion_chance": reaction_discussion_value,
+        }
+    )
 
     await _prompt_reaction_sleeps(message, state)
     await state.set_state(startaccount.reaction_sleeps)
@@ -2006,6 +2052,7 @@ async def add_channels(message: Message, state: FSMContext) -> None:
     chance = state_data.get("chance")
     reaction_sleeps = state_data.get("reaction_sleeps")
     reaction_chance = state_data.get("reaction_chance")
+    reaction_discussion_chance = state_data.get("reaction_discussion_chance")
     reaction_emojis = state_data.get("reaction_emojis")
     reaction_limit = state_data.get("reaction_limit")
     reaction_limit_set = state_data.get("reaction_limit_set")
@@ -2087,6 +2134,7 @@ async def add_channels(message: Message, state: FSMContext) -> None:
         f"account_id={account_id}, sleep_min={sleep_min}, sleep_max={sleep_max}, chance={chance}, "
         f"system_promt={system_promt}, reaction_sleep_min={reaction_sleep_min}, "
         f"reaction_sleep_max={reaction_sleep_max}, reaction_chance={reaction_chance}, "
+        f"reaction_discussion_chance={reaction_discussion_chance}, "
         f"reaction_emojis={reaction_emojis}, reaction_limit={reaction_limit}"
     )
     await bot.send_message(
@@ -2095,6 +2143,7 @@ async def add_channels(message: Message, state: FSMContext) -> None:
         f"account_id={account_id}, sleep_min={sleep_min}, sleep_max={sleep_max}, chance={chance}, "
         f"system_promt={system_promt}, reaction_sleep_min={reaction_sleep_min}, "
         f"reaction_sleep_max={reaction_sleep_max}, reaction_chance={reaction_chance}, "
+        f"reaction_discussion_chance={reaction_discussion_chance}, "
         f"reaction_emojis={reaction_emojis}, reaction_limit={reaction_limit}"
     )
 
@@ -2107,6 +2156,7 @@ async def add_channels(message: Message, state: FSMContext) -> None:
         "reaction_sleep_min": reaction_sleep_min,
         "reaction_sleep_max": reaction_sleep_max,
         "reaction_chance": reaction_chance,
+        "reaction_discussion_chance": reaction_discussion_chance,
         "reaction_emojis": reaction_emojis,
     }
     if reaction_limit_set:
@@ -2119,6 +2169,7 @@ async def add_channels(message: Message, state: FSMContext) -> None:
             "reaction_sleep_min": reaction_sleep_min,
             "reaction_sleep_max": reaction_sleep_max,
             "reaction_chance": reaction_chance,
+            "reaction_discussion_chance": reaction_discussion_chance,
             "reaction_emojis": reaction_emojis,
         }
         if reaction_limit_set:
@@ -2168,7 +2219,12 @@ async def send_comments(userid, session, account_id):
 
         xsleep, ysleep = sleep_min, sleep_max
         reaction_emojis: List[str] = account.get("reaction_emojis") or []
-        reaction_chance = account.get("reaction_chance") or 0
+        reaction_chance = account.get("reaction_chance")
+        if reaction_chance is None:
+            reaction_chance = 0
+        reaction_discussion_chance = account.get("reaction_discussion_chance")
+        if reaction_discussion_chance is None:
+            reaction_discussion_chance = reaction_chance
         reaction_sleep_min = account.get("reaction_sleep_min")
         reaction_sleep_max = account.get("reaction_sleep_max")
         reaction_limit_per_message = account.get("reaction_limit_per_message")
@@ -2225,6 +2281,7 @@ async def send_comments(userid, session, account_id):
                 system_promt=system_promt,
                 reaction_emojis=reaction_emojis,
                 reaction_chance=reaction_chance,
+                reaction_discussion_chance=reaction_discussion_chance,
                 reaction_sleep_min=reaction_sleep_min,
                 reaction_sleep_max=reaction_sleep_max,
                 reaction_limit_per_message=reaction_limit_per_message,
@@ -2787,6 +2844,7 @@ async def add_regular_channels(message: Message, state: FSMContext) -> None:
     }
     if data is not None:
         update_kwargs["reaction_chance"] = data.get("reaction_chance")
+        update_kwargs["reaction_discussion_chance"] = data.get("reaction_discussion_chance")
         update_kwargs["reaction_sleep_min"] = reaction_sleep_min
         update_kwargs["reaction_sleep_max"] = reaction_sleep_max
         update_kwargs["reaction_emojis"] = data.get("reaction_emojis")
@@ -3255,6 +3313,10 @@ async def get_account_summary(account_id):
     chance = sanitize_field(account.get('chance', 'N/A'))
     reaction_chance_value = account.get('reaction_chance')
     reaction_chance_display = _format_chance(reaction_chance_value)
+    reaction_discussion_chance_value = account.get('reaction_discussion_chance')
+    if reaction_discussion_chance_value is None:
+        reaction_discussion_chance_value = reaction_chance_value
+    reaction_discussion_chance_display = _format_chance(reaction_discussion_chance_value)
     reaction_sleep_min_value = account.get('reaction_sleep_min')
     reaction_sleep_max_value = account.get('reaction_sleep_max')
     reaction_limit_value = account.get('reaction_limit_per_message')
@@ -3266,6 +3328,7 @@ async def get_account_summary(account_id):
     reaction_emojis_list = account.get('reaction_emojis') or []
     reaction_emojis_display = " ".join(reaction_emojis_list) if reaction_emojis_list else "не заданы"
     reaction_chance = escape_markdown_text(reaction_chance_display)
+    reaction_discussion_chance = escape_markdown_text(reaction_discussion_chance_display)
     reaction_delay = escape_markdown_text(reaction_delay_display)
     reaction_emojis = escape_markdown_text(reaction_emojis_display)
     reaction_limit = escape_markdown_text(reaction_limit_display)
@@ -3285,6 +3348,7 @@ async def get_account_summary(account_id):
 • Задержка: {sleep_min}-{sleep_max} сек
 • Шанс комментирования: {chance}%
 • Шанс реакции: {reaction_chance}
+• Шанс реакции в обсуждениях: {reaction_discussion_chance}
 • Задержка реакции: {reaction_delay}
 • Эмодзи реакций: {reaction_emojis}
 • Лимит реакций на пост: {reaction_limit}

--- a/test_add_regular_channels.py
+++ b/test_add_regular_channels.py
@@ -43,6 +43,7 @@ def test_add_regular_channels_success_and_failure(monkeypatch):
         "systempromt": "Test prompt",
         "sleeps": "5-10",
         "reaction_chance": 60,
+        "reaction_discussion_chance": 40,
         "reaction_sleeps": "3-7",
         "reaction_emojis": ["🔥", "👍"],
     }
@@ -88,6 +89,7 @@ def test_add_regular_channels_success_and_failure(monkeypatch):
     assert captured_update["kwargs"]["reaction_sleep_min"] == 3
     assert captured_update["kwargs"]["reaction_sleep_max"] == 7
     assert captured_update["kwargs"]["reaction_emojis"] == ["🔥", "👍"]
+    assert captured_update["kwargs"]["reaction_discussion_chance"] == 40
 
     failure_notifications = [msg for msg in recorded_messages if "Не удалось вступить" in msg[1]]
     assert failure_notifications, "Пользователь должен получать уведомление об ошибке"

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -117,6 +117,7 @@ async def test_discussion_reply_from_user_triggers_comment_and_reaction(monkeypa
             system_promt="prompt",
             reaction_emojis=["🔥"],
             reaction_chance=100,
+            reaction_discussion_chance=100,
             reaction_sleep_min=0,
             reaction_sleep_max=0,
             reaction_limit_per_message=5,
@@ -135,6 +136,134 @@ async def test_discussion_reply_from_user_triggers_comment_and_reaction(monkeypa
     assert "success" in statuses
     assert "reaction_success" in statuses
     assert len(updated_reactions) == 1
+
+
+@pytest.mark.anyio
+async def test_discussion_and_channel_reaction_chances_are_distinct(monkeypatch):
+    userid = 123
+    session = "+100500"
+    account_id = 42
+
+    original_active_sessions = dict(main.active_sessions)
+    original_quiet = set(main.quiet_sessions_notified)
+
+    main.active_sessions.clear()
+    main.quiet_sessions_notified.clear()
+    key = main.make_session_key(userid, session)
+    main.active_sessions[key] = True
+
+    client = DummyClient()
+
+    chat = types.SimpleNamespace(id=-2000000000, permissions=None, type="supergroup")
+    reply_to_message = types.SimpleNamespace(
+        forward_from_chat=types.SimpleNamespace(username="source_channel"),
+        forward_from_message_id=321,
+    )
+    from_user = types.SimpleNamespace(is_self=False)
+
+    discussion_message = types.SimpleNamespace(
+        chat=chat,
+        text="Discussion reply",
+        caption=None,
+        id=111,
+        reply_to_message=reply_to_message,
+        from_user=from_user,
+    )
+
+    channel_message = types.SimpleNamespace(
+        chat=chat,
+        text="Channel post",
+        caption=None,
+        id=222,
+        reply_to_message=None,
+        from_user=from_user,
+    )
+
+    async def fake_bot_send_message(chat_id, text):
+        return None
+
+    async def fake_add_comment_log(*args, **kwargs):
+        return None
+
+    def fake_generate_comment(post_text, system_prompt):
+        return f"comment:{post_text}:{system_prompt}"
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    async def fake_count_reactions(*args, **kwargs):
+        return 0
+
+    def fake_randint(a, b):
+        return 1
+
+    def fake_uniform(a, b):
+        return 0
+
+    updated_reactions: list[tuple[int, datetime]] = []
+
+    async def fake_update_last_reaction_at(account, ts):
+        updated_reactions.append((account, ts))
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
+    monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
+    monkeypatch.setattr(main, "generate_comment", fake_generate_comment)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "count_reactions_for_message", fake_count_reactions)
+    monkeypatch.setattr(main.random, "randint", fake_randint)
+    monkeypatch.setattr(main.random, "uniform", fake_uniform)
+    monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
+
+    try:
+        await main._handle_linked_channel_message(
+            client,
+            discussion_message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=100,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥"],
+            reaction_chance=100,
+            reaction_discussion_chance=0,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=5,
+            last_reaction_at=None,
+        )
+
+        assert not client.sent_reactions, "Реакции на обсуждение не должны отправляться при нулевом шансе"
+
+        await main._handle_linked_channel_message(
+            client,
+            channel_message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=100,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥"],
+            reaction_chance=100,
+            reaction_discussion_chance=0,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=5,
+            last_reaction_at=None,
+        )
+    finally:
+        main.active_sessions.clear()
+        main.active_sessions.update(original_active_sessions)
+        main.quiet_sessions_notified.clear()
+        main.quiet_sessions_notified.update(original_quiet)
+
+    assert client.sent_reactions, "Реакция для поста канала должна быть отправлена"
+    assert len(updated_reactions) >= 1
 
 
 @pytest.mark.anyio
@@ -216,6 +345,7 @@ async def test_reaction_skipped_when_limit_reached(monkeypatch):
             system_promt="prompt",
             reaction_emojis=["🔥"],
             reaction_chance=100,
+            reaction_discussion_chance=100,
             reaction_sleep_min=0,
             reaction_sleep_max=0,
             reaction_limit_per_message=5,
@@ -321,6 +451,7 @@ async def test_reaction_skipped_when_cooldown_active(monkeypatch):
             system_promt="prompt",
             reaction_emojis=["🔥"],
             reaction_chance=100,
+            reaction_discussion_chance=100,
             reaction_sleep_min=0,
             reaction_sleep_max=0,
             reaction_limit_per_message=5,
@@ -431,6 +562,7 @@ async def test_reaction_occurs_after_cooldown(monkeypatch):
             system_promt="prompt",
             reaction_emojis=["🔥"],
             reaction_chance=100,
+            reaction_discussion_chance=100,
             reaction_sleep_min=0,
             reaction_sleep_max=0,
             reaction_limit_per_message=5,

--- a/test_logic.py
+++ b/test_logic.py
@@ -93,6 +93,7 @@ def test_sql_generation():
     sleep_max = 25
     channels = ["@test1", "@test2"]
     reaction_chance = 40
+    reaction_discussion_chance = 35
     reaction_sleep_min = 5
     reaction_sleep_max = 12
     reaction_emojis = ["🔥", "👍"]
@@ -116,6 +117,9 @@ def test_sql_generation():
     if reaction_chance is not None:
         updates.append("reaction_chance = $%d" % (len(values) + 1))
         values.append(reaction_chance)
+    if reaction_discussion_chance is not None:
+        updates.append("reaction_discussion_chance = $%d" % (len(values) + 1))
+        values.append(reaction_discussion_chance)
     if reaction_sleep_min is not None:
         updates.append("reaction_sleep_min = $%d" % (len(values) + 1))
         values.append(reaction_sleep_min)

--- a/test_settings_save.py
+++ b/test_settings_save.py
@@ -37,6 +37,7 @@ async def test_settings_save(tmp_path, monkeypatch):
         sleep_min=15,
         sleep_max=25,
         reaction_chance=70,
+        reaction_discussion_chance=55,
         reaction_sleep_min=3,
         reaction_sleep_max=6,
         reaction_emojis=["🔥", "👍"],
@@ -48,6 +49,7 @@ async def test_settings_save(tmp_path, monkeypatch):
     assert stored["sleep_min"] == 15
     assert stored["sleep_max"] == 25
     assert stored["reaction_chance"] == 70
+    assert stored["reaction_discussion_chance"] == 55
     assert stored["reaction_sleep_min"] == 3
     assert stored["reaction_sleep_max"] == 6
     assert stored["reaction_emojis"] == ["🔥", "👍"]


### PR DESCRIPTION
## Summary
- add a reaction_discussion_chance column for accounts and persist it through settings updates
- extend the reaction settings flow to collect distinct chances for posts vs. discussions and use the new value when reacting
- cover the new behaviour with updated unit tests including discussion-specific reaction odds

## Testing
- pytest test_linked_discussion_handler.py test_add_regular_channels.py test_settings_save.py test_logic.py

------
https://chatgpt.com/codex/tasks/task_e_68e1fc8e235883308f387cae48ce1a93