### PR TITLE
Add dedicated reaction settings flow and update tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -137,12 +137,15 @@ class startaccount(StatesGroup):
     systempromt = State()
     sleeps = State()
     chance = State()
-    reaction_limit = State()
-    reaction_chance = State()
-    reaction_sleeps = State()
-    reaction_emojis = State()
     regular_channels = State()
     warmup_channels = State()
+
+
+class reactionsettings(StatesGroup):
+    limit = State()
+    chance = State()
+    sleeps = State()
+    emojis = State()
 
 
 class warmupsettings(StatesGroup):
@@ -882,11 +885,13 @@ async def main_message(message):
         button_status = types.InlineKeyboardButton(text=status_button_text, callback_data=status_button_callback)
         button_delete = types.InlineKeyboardButton(text="Удалить", callback_data=f"del_{call}")
         button_warmup = types.InlineKeyboardButton(text="Прогрев", callback_data=f"warmup_{call}")
+        button_reactions = types.InlineKeyboardButton(
+            text="🎯 Реакции на посты и ответы", callback_data=f"reaction_{call}"
+        )
 
-        if is_running:
-            builder.row(button_info, button_status, button_warmup)
-        else:
-            builder.row(button_info, button_status, button_warmup)
+        builder.row(button_info, button_status, button_warmup)
+        builder.row(button_reactions)
+        if not is_running:
             builder.row(button_delete)
 
 
@@ -1178,6 +1183,28 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
         return
 
 
+    elif call.startswith('reaction_'):
+        session = str(call).split('_', 1)[1]
+
+        account_row = await get_account_by_session(callback_query.from_user.id, session)
+        if not account_row:
+            await bot.send_message(callback_query.from_user.id, "Аккаунт не найден в базе данных")
+            await main_message(callback_query)
+            return
+
+        await state.clear()
+        await state.update_data(
+            {
+                "account": session,
+                "account_id": account_row["id"],
+                "reaction_limit_set": False,
+                "apply_reactions_to_all": False,
+            }
+        )
+        await callback_query.answer()
+        await _prompt_reaction_limit(callback_query, state)
+        await state.set_state(reactionsettings.limit)
+
     elif 'start_' in call:
 
         session = str(call).split('_')[1]
@@ -1186,7 +1213,7 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
         if active_sessions.get(key):
             await bot.send_message(callback_query.from_user.id, f"Аккаунт {session} уже запущен")
             return
-        
+
 
         if await check_account(callback_query.from_user.id, session):
 
@@ -1197,29 +1224,17 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
                     await main_message(callback_query)
                     return
 
-                # Все аккаунты проходят через диалог настройки
                 account_id = account_row["id"]
+                await state.clear()
                 await state.update_data({"account": session, "account_id": account_id})
-                await state.update_data({"apply_reactions_to_all": False})
 
-                current_chance = account_row.get("chance")
-                if current_chance is None:
-                    chance_hint = "не задан"
-                else:
-                    chance_hint = f"{current_chance}%"
-
-                await bot.send_message(
-                    callback_query.from_user.id,
-                    "Текущий шанс комментирования: {hint}.\n"
-                    "Отправьте новое значение от 0 до 100 или '-' для сохранения текущего.".format(
-                        hint=chance_hint
-                    ),
-                )
-                await state.set_state(startaccount.chance)
+                await callback_query.answer()
+                await _prompt_system_prompt(callback_query, state)
+                await state.set_state(startaccount.systempromt)
             except Exception as e:
                 await bot.send_message(callback_query.from_user.id, f"Ошибка: {str(e)}")
                 await main_message(callback_query)
-        else:   
+        else:
             await main_message(callback_query)
             return
 
@@ -1550,8 +1565,15 @@ async def _prompt_reaction_chance(message: Message, state: FSMContext) -> None:
     if stored_discussion is None:
         stored_discussion = stored
 
-    display = _format_chance(stored)
-    discussion_display = _format_chance(stored_discussion)
+    if stored is None:
+        display = "0% (по умолчанию)"
+    else:
+        display = _format_chance(stored)
+
+    if stored_discussion is None:
+        discussion_display = "0% (по умолчанию)"
+    else:
+        discussion_display = _format_chance(stored_discussion)
     await bot.send_message(
         message.from_user.id,
         (
@@ -1563,7 +1585,7 @@ async def _prompt_reaction_chance(message: Message, state: FSMContext) -> None:
     )
 
 
-@dp.message(startaccount.reaction_limit)
+@dp.message(reactionsettings.limit)
 async def add_reaction_limit(message: Message, state: FSMContext) -> None:
     data, _, account = await _load_account_data(state)
 
@@ -1585,7 +1607,7 @@ async def add_reaction_limit(message: Message, state: FSMContext) -> None:
             }
         )
         await _prompt_reaction_chance(message, state)
-        await state.set_state(startaccount.reaction_chance)
+        await state.set_state(reactionsettings.chance)
         return
 
     lowered = incoming.lower()
@@ -1597,7 +1619,7 @@ async def add_reaction_limit(message: Message, state: FSMContext) -> None:
             }
         )
         await _prompt_reaction_chance(message, state)
-        await state.set_state(startaccount.reaction_chance)
+        await state.set_state(reactionsettings.chance)
         return
 
     try:
@@ -1633,7 +1655,7 @@ async def add_reaction_limit(message: Message, state: FSMContext) -> None:
         }
     )
     await _prompt_reaction_chance(message, state)
-    await state.set_state(startaccount.reaction_chance)
+    await state.set_state(reactionsettings.chance)
 
 
 async def _prompt_reaction_sleeps(message: Message, state: FSMContext) -> None:
@@ -1673,7 +1695,12 @@ async def _prompt_reaction_emojis(message: Message, state: FSMContext) -> None:
     if stored_emojis is None:
         stored_emojis = data.get("reaction_emojis")
 
-    display = " ".join(stored_emojis) if stored_emojis else "не заданы"
+    if stored_emojis:
+        display = " ".join(stored_emojis)
+    elif stored_emojis == []:
+        display = "не заданы"
+    else:
+        display = "не заданы (по умолчанию)"
     builder = InlineKeyboardBuilder()
     builder.button(text="Применить всем аккаунтам", callback_data="reaction_apply_all")
     builder.adjust(1)
@@ -1727,7 +1754,7 @@ async def _prepare_regular_channels_prompt(message: Message, state: FSMContext) 
         await main_message(message)
 
 
-@dp.message(startaccount.reaction_chance)
+@dp.message(reactionsettings.chance)
 async def add_reaction_chance(message: Message, state: FSMContext) -> None:
     data, _, account = await _load_account_data(state)
 
@@ -1748,18 +1775,17 @@ async def add_reaction_chance(message: Message, state: FSMContext) -> None:
     incoming = (message.text or "").strip()
 
     if incoming == "-":
-        if stored_chance is None:
-            await bot.send_message(
-                message.from_user.id,
-                "Текущий шанс реакции не задан. Укажите значение от 0 до 100.",
-            )
-            await _prompt_reaction_chance(message, state)
-            return
+        def _convert_optional(value: Optional[Union[int, str]]) -> Optional[int]:
+            if value is None or value == "":
+                return None
+            converted = int(value)
+            if converted < 0 or converted > 100:
+                raise ValueError
+            return converted
+
         try:
-            reaction_chance_value = int(stored_chance)
-            reaction_discussion_value = int(
-                stored_discussion if stored_discussion is not None else stored_chance
-            )
+            reaction_chance_value = _convert_optional(stored_chance)
+            reaction_discussion_value = _convert_optional(stored_discussion)
         except (TypeError, ValueError):
             await bot.send_message(
                 message.from_user.id,
@@ -1811,10 +1837,10 @@ async def add_reaction_chance(message: Message, state: FSMContext) -> None:
     )
 
     await _prompt_reaction_sleeps(message, state)
-    await state.set_state(startaccount.reaction_sleeps)
+    await state.set_state(reactionsettings.sleeps)
 
 
-@dp.message(startaccount.reaction_sleeps)
+@dp.message(reactionsettings.sleeps)
 async def add_reaction_sleeps(message: Message, state: FSMContext) -> None:
     data, _, account = await _load_account_data(state)
 
@@ -1848,10 +1874,10 @@ async def add_reaction_sleeps(message: Message, state: FSMContext) -> None:
         await state.update_data({"reaction_sleeps": f"{reaction_min}-{reaction_max}"})
 
     await _prompt_reaction_emojis(message, state)
-    await state.set_state(startaccount.reaction_emojis)
+    await state.set_state(reactionsettings.emojis)
 
 
-@dp.message(startaccount.reaction_emojis)
+@dp.message(reactionsettings.emojis)
 async def add_reaction_emojis(message: Message, state: FSMContext) -> None:
     data, _, account = await _load_account_data(state)
 
@@ -1864,7 +1890,7 @@ async def add_reaction_emojis(message: Message, state: FSMContext) -> None:
     incoming = (message.text or "").strip()
 
     if incoming == "-":
-        emoji_list = stored_emojis or []
+        emoji_list = stored_emojis
     else:
         normalized = incoming.replace("\n", " ").replace(",", " ")
         tokens = [token for token in normalized.split(" ") if token]
@@ -1887,7 +1913,60 @@ async def add_reaction_emojis(message: Message, state: FSMContext) -> None:
 
     await state.update_data({"reaction_emojis": emoji_list})
 
-    await _prepare_regular_channels_prompt(message, state)
+    await _save_reaction_settings(message, state)
+
+
+async def _save_reaction_settings(message: Message, state: FSMContext) -> None:
+    data, account_id, _ = await _load_account_data(state)
+    session = data.get("account") if data else None
+
+    if not account_id:
+        await bot.send_message(message.from_user.id, "Ошибка: аккаунт не найден. Попробуйте снова.")
+        await state.clear()
+        await main_message(message)
+        return
+
+    reaction_sleep_min = reaction_sleep_max = None
+    reaction_range_raw = data.get("reaction_sleeps") if data else None
+    if reaction_range_raw:
+        parsed = _parse_sleep_range_input(str(reaction_range_raw))
+        if parsed:
+            reaction_sleep_min, reaction_sleep_max = parsed
+
+    update_kwargs: Dict[str, Any] = {
+        "reaction_chance": data.get("reaction_chance"),
+        "reaction_discussion_chance": data.get("reaction_discussion_chance"),
+        "reaction_sleep_min": reaction_sleep_min,
+        "reaction_sleep_max": reaction_sleep_max,
+        "reaction_emojis": data.get("reaction_emojis"),
+    }
+
+    if data.get("reaction_limit_set"):
+        update_kwargs["reaction_limit_per_message"] = data.get("reaction_limit")
+
+    await update_account_settings(account_id, **update_kwargs)
+
+    if data.get("apply_reactions_to_all"):
+        bulk_kwargs = dict(update_kwargs)
+        await bulk_update_reaction_settings(message.from_user.id, **bulk_kwargs)
+        await bot.send_message(
+            message.from_user.id,
+            "Настройки реакций применены ко всем вашим аккаунтам.",
+        )
+        await bot.send_message(
+            log_channel,
+            f"Аккаунт {session}: настройки реакций применены ко всем аккаунтам пользователя.",
+        )
+
+    await bot.send_message(message.from_user.id, "Настройки реакций сохранены.")
+    if session:
+        await bot.send_message(
+            log_channel,
+            f"Аккаунт {session}: настройки реакций обновлены.",
+        )
+
+    await state.clear()
+    await main_message(message)
 
 
 def _parse_sleep_range_input(text: str) -> Optional[Tuple[int, int]]:
@@ -1954,8 +2033,7 @@ async def add_chance(message: Message, state: FSMContext) -> None:
 
     await state.update_data({"chance": chance_value})
 
-    await _prompt_system_prompt(message, state)
-    await state.set_state(startaccount.systempromt)
+    await _prepare_regular_channels_prompt(message, state)
         
 
 
@@ -2037,8 +2115,8 @@ async def add_sleeps(message: Message, state: FSMContext) -> None:
         sleep_min, sleep_max = parsed_range
         await state.update_data({"sleeps": f"{sleep_min}-{sleep_max}"})
 
-    await _prompt_reaction_limit(message, state)
-    await state.set_state(startaccount.reaction_limit)
+    await _prompt_chance(message, state)
+    await state.set_state(startaccount.chance)
 
 
 @dp.message(startaccount.channels)
@@ -2050,14 +2128,6 @@ async def add_channels(message: Message, state: FSMContext) -> None:
     sleeps = state_data.get("sleeps")
     system_promt = state_data.get("systempromt")
     chance = state_data.get("chance")
-    reaction_sleeps = state_data.get("reaction_sleeps")
-    reaction_chance = state_data.get("reaction_chance")
-    reaction_discussion_chance = state_data.get("reaction_discussion_chance")
-    reaction_emojis = state_data.get("reaction_emojis")
-    reaction_limit = state_data.get("reaction_limit")
-    reaction_limit_set = state_data.get("reaction_limit_set")
-    apply_reactions_to_all = state_data.get("apply_reactions_to_all")
-
     print(f"DEBUG: State data - sleeps: {sleeps}, system_promt: {system_promt}, chance: {chance}")
 
     account_id = state_data.get("account_id")
@@ -2110,7 +2180,6 @@ async def add_channels(message: Message, state: FSMContext) -> None:
 
     # Сохраняем все настройки в базу данных
     sleep_min, sleep_max = None, None
-    reaction_sleep_min, reaction_sleep_max = None, None
     if sleeps and '-' in sleeps:
         try:
             sleep_parts = sleeps.split('-')
@@ -2119,72 +2188,26 @@ async def add_channels(message: Message, state: FSMContext) -> None:
                 sleep_max = int(sleep_parts[1])
         except ValueError:
             pass
-
-    if isinstance(reaction_sleeps, str) and '-' in reaction_sleeps:
-        try:
-            reaction_parts = reaction_sleeps.split('-')
-            if len(reaction_parts) == 2:
-                reaction_sleep_min = int(reaction_parts[0])
-                reaction_sleep_max = int(reaction_parts[1])
-        except ValueError:
-            pass
-
     print(
         "DEBUG: About to save settings - "
         f"account_id={account_id}, sleep_min={sleep_min}, sleep_max={sleep_max}, chance={chance}, "
-        f"system_promt={system_promt}, reaction_sleep_min={reaction_sleep_min}, "
-        f"reaction_sleep_max={reaction_sleep_max}, reaction_chance={reaction_chance}, "
-        f"reaction_discussion_chance={reaction_discussion_chance}, "
-        f"reaction_emojis={reaction_emojis}, reaction_limit={reaction_limit}"
+        f"system_promt={system_promt}"
     )
     await bot.send_message(
         log_channel,
         "DEBUG: About to save settings - "
         f"account_id={account_id}, sleep_min={sleep_min}, sleep_max={sleep_max}, chance={chance}, "
-        f"system_promt={system_promt}, reaction_sleep_min={reaction_sleep_min}, "
-        f"reaction_sleep_max={reaction_sleep_max}, reaction_chance={reaction_chance}, "
-        f"reaction_discussion_chance={reaction_discussion_chance}, "
-        f"reaction_emojis={reaction_emojis}, reaction_limit={reaction_limit}"
+        f"system_promt={system_promt}"
     )
 
     update_kwargs: Dict[str, Any] = {
-        "channels": channels,
         "sleep_min": sleep_min,
         "sleep_max": sleep_max,
         "chance": chance,
         "system_prompt": system_promt,
-        "reaction_sleep_min": reaction_sleep_min,
-        "reaction_sleep_max": reaction_sleep_max,
-        "reaction_chance": reaction_chance,
-        "reaction_discussion_chance": reaction_discussion_chance,
-        "reaction_emojis": reaction_emojis,
     }
-    if reaction_limit_set:
-        update_kwargs["reaction_limit_per_message"] = reaction_limit
 
     await update_account_settings(account_id, **update_kwargs)
-
-    if apply_reactions_to_all:
-        bulk_kwargs: Dict[str, Any] = {
-            "reaction_sleep_min": reaction_sleep_min,
-            "reaction_sleep_max": reaction_sleep_max,
-            "reaction_chance": reaction_chance,
-            "reaction_discussion_chance": reaction_discussion_chance,
-            "reaction_emojis": reaction_emojis,
-        }
-        if reaction_limit_set:
-            bulk_kwargs["reaction_limit_per_message"] = reaction_limit
-
-        await bulk_update_reaction_settings(message.from_user.id, **bulk_kwargs)
-        await bot.send_message(
-            message.from_user.id,
-            "Настройки реакций применены ко всем вашим аккаунтам."
-        )
-        await bot.send_message(
-            log_channel,
-            f"Аккаунт {session}: настройки реакций применены ко всем аккаунтам пользователя."
-        )
-        await state.update_data({"apply_reactions_to_all": False})
 
     print(f"DEBUG: Settings saved successfully for account_id={account_id}")
     await bot.send_message(log_channel, f"DEBUG: Settings saved successfully for account_id={account_id}")
@@ -2842,12 +2865,6 @@ async def add_regular_channels(message: Message, state: FSMContext) -> None:
         "sleep_min": sleep_min,
         "sleep_max": sleep_max,
     }
-    if data is not None:
-        update_kwargs["reaction_chance"] = data.get("reaction_chance")
-        update_kwargs["reaction_discussion_chance"] = data.get("reaction_discussion_chance")
-        update_kwargs["reaction_sleep_min"] = reaction_sleep_min
-        update_kwargs["reaction_sleep_max"] = reaction_sleep_max
-        update_kwargs["reaction_emojis"] = data.get("reaction_emojis")
     if channels_to_update is not None:
         update_kwargs["channels"] = channels_to_update
 

--- a/test_add_regular_channels.py
+++ b/test_add_regular_channels.py
@@ -85,11 +85,11 @@ def test_add_regular_channels_success_and_failure(monkeypatch):
     assert captured_update["kwargs"]["system_prompt"] == "Test prompt"
     assert captured_update["kwargs"]["sleep_min"] == 5
     assert captured_update["kwargs"]["sleep_max"] == 10
-    assert captured_update["kwargs"]["reaction_chance"] == 60
-    assert captured_update["kwargs"]["reaction_sleep_min"] == 3
-    assert captured_update["kwargs"]["reaction_sleep_max"] == 7
-    assert captured_update["kwargs"]["reaction_emojis"] == ["🔥", "👍"]
-    assert captured_update["kwargs"]["reaction_discussion_chance"] == 40
+    assert "reaction_chance" not in captured_update["kwargs"]
+    assert "reaction_sleep_min" not in captured_update["kwargs"]
+    assert "reaction_sleep_max" not in captured_update["kwargs"]
+    assert "reaction_emojis" not in captured_update["kwargs"]
+    assert "reaction_discussion_chance" not in captured_update["kwargs"]
 
     failure_notifications = [msg for msg in recorded_messages if "Не удалось вступить" in msg[1]]
     assert failure_notifications, "Пользователь должен получать уведомление об ошибке"

--- a/test_main_keyboard_layout.py
+++ b/test_main_keyboard_layout.py
@@ -97,3 +97,83 @@ async def test_main_menu_keyboard_layout_no_accounts(monkeypatch):
     )
     assert bottom_row[0].text == "📊 Общая статистика"
     assert bottom_row[1].text == "⚙️ Настройки прогрева"
+
+
+@pytest.mark.anyio
+async def test_main_menu_keyboard_layout_with_account_shows_reaction_button(monkeypatch):
+    user_id = 123
+    session_file = os.path.normpath(f"sessions/{user_id}/79990000000.session")
+    existing_dirs: set[str] = set()
+    existing_files: set[str] = {session_file}
+
+    def _norm(path: str) -> str:
+        return os.path.normpath(path)
+
+    def fake_isdir(path: str) -> bool:
+        return _norm(path) in existing_dirs
+
+    def fake_makedirs(path: str, exist_ok: bool = False) -> None:  # noqa: ARG001
+        norm_path = _norm(path)
+        if norm_path in ("", "."):
+            return
+        parts = norm_path.split(os.sep)
+        cumulative = []
+        for part in parts:
+            cumulative.append(part)
+            existing_dirs.add(_norm(os.sep.join(cumulative)))
+
+    def fake_listdir(path: str) -> list[str]:  # noqa: ARG001
+        norm_path = _norm(path)
+        user_dir = _norm(f"sessions/{user_id}")
+        if norm_path == user_dir:
+            return ["79990000000.session"]
+        return []
+
+    def fake_exists(path: str) -> bool:
+        return _norm(path) in existing_files
+
+    async def fake_ensure_user(uid: int) -> None:  # noqa: ARG001
+        return None
+
+    async def fake_get_accounts(uid: int):  # noqa: ARG001
+        return [{"phone": "79990000000", "status": "stopped"}]
+
+    async def fake_ensure_account(user_id: int, phone: str, session_path: str):  # noqa: ARG001
+        return None
+
+    sent: dict[str, object] = {}
+
+    async def fake_send_message(chat_id: int, text: str, reply_markup=None, **kwargs):  # noqa: ANN001
+        sent.update(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "markup": reply_markup,
+                "kwargs": kwargs,
+            }
+        )
+        return types.SimpleNamespace(message_id=1)
+
+    monkeypatch.setattr(main.os.path, "isdir", fake_isdir)
+    monkeypatch.setattr(main.os, "makedirs", fake_makedirs)
+    monkeypatch.setattr(main.os, "listdir", fake_listdir)
+    monkeypatch.setattr(main.os.path, "exists", fake_exists)
+    monkeypatch.setattr(main, "ensure_user", fake_ensure_user)
+    monkeypatch.setattr(main, "get_accounts_for_user", fake_get_accounts)
+    monkeypatch.setattr(main, "ensure_account", fake_ensure_account)
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+    main.active_sessions.clear()
+
+    await main.main_message(DummyMessage(user_id))
+
+    markup = sent.get("markup")
+    assert markup is not None, "Главное меню должно содержать клавиатуру"
+
+    reaction_buttons = [
+        button
+        for row in markup.inline_keyboard
+        for button in row
+        if button.callback_data == "reaction_79990000000"
+    ]
+    assert reaction_buttons, "Для аккаунта должна появиться кнопка настроек реакций"
+    assert reaction_buttons[0].text == "🎯 Реакции на посты и ответы"

--- a/test_settings_save.py
+++ b/test_settings_save.py
@@ -2,8 +2,41 @@
 from __future__ import annotations
 
 import importlib
+import os
+import types
 
 import pytest
+
+os.environ.setdefault("API_ID", "1")
+os.environ.setdefault("API_HASH", "hash")
+os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
+
+import main
+
+
+class DummyState:
+    def __init__(self, data: dict[str, object]):
+        self._data = data
+        self.cleared = False
+        self.set_states: list[object] = []
+
+    async def get_data(self) -> dict[str, object]:
+        return self._data
+
+    async def update_data(self, update: dict[str, object]) -> None:
+        self._data.update(update)
+
+    async def set_state(self, state: object) -> None:
+        self.set_states.append(state)
+
+    async def clear(self) -> None:
+        self.cleared = True
+
+
+class DummyMessage:
+    def __init__(self, text: str, user_id: int):
+        self.text = text
+        self.from_user = types.SimpleNamespace(id=user_id)
 
 
 @pytest.fixture
@@ -55,3 +88,120 @@ async def test_settings_save(tmp_path, monkeypatch):
     assert stored["reaction_emojis"] == ["🔥", "👍"]
 
     await db.close_db()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reaction_settings_flow_saves_values(monkeypatch):
+    user_id = 42
+    state_data = {"account": "79990000000", "account_id": 123}
+    state = DummyState(state_data)
+    account_info = {
+        "reaction_chance": None,
+        "reaction_discussion_chance": None,
+        "reaction_sleep_min": None,
+        "reaction_sleep_max": None,
+        "reaction_emojis": None,
+    }
+
+    captured_update: dict[str, object] = {}
+    captured_bulk: list[tuple[int, dict[str, object]]] = []
+    sent_messages: list[tuple[int, str]] = []
+    main_message_called = False
+
+    async def fake_load_account_data(dummy_state):  # noqa: ANN001
+        return state_data, state_data["account_id"], account_info
+
+    async def fake_update_account_settings(account_id: int, **kwargs):  # noqa: ANN001
+        captured_update["account_id"] = account_id
+        captured_update["kwargs"] = kwargs
+
+    async def fake_bulk_update(user: int, **kwargs):  # noqa: ANN001
+        captured_bulk.append((user, kwargs))
+
+    async def fake_send_message(chat_id: int, text: str, **kwargs):  # noqa: ANN001
+        sent_messages.append((chat_id, text))
+        return types.SimpleNamespace(message_id=1)
+
+    async def fake_main_message(message):  # noqa: ANN001
+        nonlocal main_message_called
+        main_message_called = True
+
+    monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
+    monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
+    monkeypatch.setattr(main, "bulk_update_reaction_settings", fake_bulk_update)
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+    monkeypatch.setattr(main, "main_message", fake_main_message)
+
+    await main.add_reaction_limit(DummyMessage("10", user_id), state)
+    assert state.set_states[-1] == main.reactionsettings.chance
+
+    await main.add_reaction_chance(DummyMessage("70/50", user_id), state)
+    assert state.set_states[-1] == main.reactionsettings.sleeps
+
+    await main.add_reaction_sleeps(DummyMessage("2-4", user_id), state)
+    assert state.set_states[-1] == main.reactionsettings.emojis
+
+    await main.add_reaction_emojis(DummyMessage("🔥 👍", user_id), state)
+
+    assert captured_update, "update_account_settings должна вызываться"
+    assert captured_update["account_id"] == 123
+    kwargs = captured_update["kwargs"]
+    assert kwargs["reaction_limit_per_message"] == 10
+    assert kwargs["reaction_chance"] == 70
+    assert kwargs["reaction_discussion_chance"] == 50
+    assert kwargs["reaction_sleep_min"] == 2
+    assert kwargs["reaction_sleep_max"] == 4
+    assert kwargs["reaction_emojis"] == ["🔥", "👍"]
+    assert not captured_bulk, "Применение ко всем аккаунтам не должно вызываться без кнопки"
+    assert state.cleared is True
+    assert main_message_called is True
+    assert sent_messages, "Пользователь должен получить подтверждение сохранения"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reaction_settings_flow_with_defaults(monkeypatch):
+    user_id = 43
+    state_data = {"account": "79995550000", "account_id": 321}
+    state = DummyState(state_data)
+    account_info = {
+        "reaction_chance": None,
+        "reaction_discussion_chance": None,
+        "reaction_sleep_min": None,
+        "reaction_sleep_max": None,
+        "reaction_emojis": None,
+    }
+
+    captured_update: dict[str, object] = {}
+
+    async def fake_load_account_data(dummy_state):  # noqa: ANN001
+        return state_data, state_data["account_id"], account_info
+
+    async def fake_update_account_settings(account_id: int, **kwargs):  # noqa: ANN001
+        captured_update["account_id"] = account_id
+        captured_update["kwargs"] = kwargs
+
+    async def fake_send_message(chat_id: int, text: str, **kwargs):  # noqa: ANN001
+        return types.SimpleNamespace(message_id=1)
+
+    async def fake_main_message(message):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
+    monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
+    monkeypatch.setattr(main, "bulk_update_reaction_settings", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+    monkeypatch.setattr(main, "main_message", fake_main_message)
+
+    await main.add_reaction_limit(DummyMessage("-", user_id), state)
+    await main.add_reaction_chance(DummyMessage("-", user_id), state)
+    await main.add_reaction_sleeps(DummyMessage("-", user_id), state)
+    await main.add_reaction_emojis(DummyMessage("-", user_id), state)
+
+    assert captured_update["account_id"] == 321
+    kwargs = captured_update["kwargs"]
+    assert "reaction_limit_per_message" not in kwargs
+    assert kwargs["reaction_chance"] is None
+    assert kwargs["reaction_discussion_chance"] is None
+    assert kwargs["reaction_sleep_min"] is None
+    assert kwargs["reaction_sleep_max"] is None
+    assert kwargs["reaction_emojis"] is None


### PR DESCRIPTION
## Summary
- add a per-account inline button that opens a dedicated reaction settings flow
- introduce a new `reactionsettings` FSM, move the reaction steps out of the main account wizard, and update the save logic with defaults
- refresh keyboard and scenario tests to cover the new button, FSM transitions, and ensure the main wizard no longer touches reaction fields

## Testing
- `pytest test_main_keyboard_layout.py`
- `pytest test_add_regular_channels.py test_settings_save.py`


------
https://chatgpt.com/codex/tasks/task_e_68e2074dc37c8330a8f2538a6cf12f5a