### PR TITLE
Escape markdown special characters in global statistics report

### DIFF
--- a/main.py
+++ b/main.py
@@ -3381,7 +3381,11 @@ def format_global_statistics_report(stats: Dict[str, Any]) -> str:
     reaction_total = comments.get("reactions_total", 0)
 
     def _format_additional(counts: Dict[str, Any], known_keys: Set[str]) -> Optional[str]:
-        extra = [f"{key}: {counts[key]}" for key in sorted(counts) if key not in known_keys]
+        extra = [
+            f"{escape_markdown_text(str(key))}: {counts[key]}"
+            for key in sorted(counts)
+            if key not in known_keys
+        ]
         if extra:
             return ", ".join(extra)
         return None
@@ -3402,12 +3406,12 @@ def format_global_statistics_report(stats: Dict[str, Any]) -> str:
     if accounts_by_mode:
         lines.append("• Режимы:")
         for mode, count in sorted(accounts_by_mode.items()):
-            lines.append(f"   ◦ {mode}: {count}")
+            lines.append(f"   ◦ {escape_markdown_text(str(mode))}: {count}")
 
     if running_by_mode:
         lines.append("• Активные по режимам:")
         for mode, count in sorted(running_by_mode.items()):
-            lines.append(f"   ◦ {mode}: {count}")
+            lines.append(f"   ◦ {escape_markdown_text(str(mode))}: {count}")
 
     lines.extend(
         [

--- a/test_bot.py
+++ b/test_bot.py
@@ -112,3 +112,61 @@ async def test_get_global_statistics_and_report(tmp_path, monkeypatch):
 
     await db_module.close_db()
 
+
+def test_format_global_statistics_report_escapes_markdown_special_chars(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123456:TEST")
+    monkeypatch.setenv("API_ID", "123")
+    monkeypatch.setenv("API_HASH", "hash")
+
+    import importlib
+    import main as main_module
+
+    main_module = importlib.reload(main_module)
+
+    stats = {
+        "accounts": {
+            "total": 1,
+            "by_status": {
+                "running_status": 1,
+                "custom_status": 2,
+            },
+            "by_mode": {
+                "mode_with_underscores": 3,
+            },
+            "running_by_mode": {
+                "mode_with_underscores": 2,
+            },
+        },
+        "comments": {
+            "total": 0,
+            "by_status": {
+                "success": 0,
+                "error": 0,
+                "skipped": 0,
+                "no_comments": 0,
+                "custom_comment_status": 1,
+            },
+            "reactions_total": 0,
+            "reactions": {
+                "success": 0,
+                "error": 0,
+                "skipped": 0,
+                "custom_reaction_status": 1,
+            },
+        },
+        "warmup": {
+            "by_status": {
+                "joined": 0,
+                "pending": 0,
+                "error": 0,
+                "custom_warmup_status": 1,
+            },
+            "total_attempts": 0,
+        },
+    }
+
+    report = main_module.format_global_statistics_report(stats)
+
+    import re
+
+    assert not re.search(r"(?<!\\)_", report)


### PR DESCRIPTION
## Summary
- escape Markdown-sensitive status and mode names before including them in the global statistics report
- add a regression test ensuring underscores in status names are escaped in the report output

## Testing
- pytest test_bot.py::test_format_global_statistics_report_escapes_markdown_special_chars -q

------
https://chatgpt.com/codex/tasks/task_e_68e23a07f5c083309caf0c23ccd970b5