### PR TITLE
Filter reaction emojis to available quick reactions

### DIFF
--- a/main.py
+++ b/main.py
@@ -2067,6 +2067,96 @@ async def add_reaction_sleeps(message: Message, state: FSMContext) -> None:
 
 
 @dp.message(reactionsettings.emojis)
+def _extract_available_reaction_emojis(available: Any) -> Set[str]:
+    result: Set[str] = set()
+    if not available:
+        return result
+
+    for item in available:
+        if item is None:
+            continue
+
+        emoji_value = getattr(item, "emoji", None)
+        if emoji_value:
+            result.add(emoji_value)
+            continue
+
+        nested = getattr(item, "reaction", None)
+        emoji_value = getattr(nested, "emoji", None)
+        if emoji_value:
+            result.add(emoji_value)
+
+    return result
+
+
+async def _get_available_quick_reaction_emojis(
+    user_id: int,
+    session: Optional[str],
+    chat_id: Optional[int] = None,
+) -> Optional[Set[str]]:
+    if not session:
+        return None
+
+    key = make_session_key(user_id, session)
+    existing_client = active_pyrogram_clients.get(key)
+
+    async def _query(client_obj: Client) -> Optional[Set[str]]:
+        try:
+            if chat_id is not None:
+                try:
+                    available = await client_obj.get_available_reactions(chat_id)
+                except TypeError:
+                    available = await client_obj.get_available_reactions()
+            else:
+                available = await client_obj.get_available_reactions()
+        except Exception:
+            logging.exception(
+                "Failed to request available reactions for session %s", session
+            )
+            return None
+
+        return _extract_available_reaction_emojis(available)
+
+    if existing_client and getattr(existing_client, "is_connected", False):
+        return await _query(existing_client)
+
+    session_dir = os.path.join("sessions", str(user_id))
+    session_name = os.path.join(session_dir, session)
+    session_file = f"{session_name}.session"
+
+    if not os.path.exists(session_file):
+        alt_session_file = f"{session_file}.session"
+        if os.path.exists(alt_session_file):
+            try:
+                shutil.copy2(alt_session_file, session_file)
+            except Exception:
+                logging.exception(
+                    "Не удалось подготовить файл сессии для получения доступных реакций: %s",
+                    alt_session_file,
+                )
+                return None
+        else:
+            logging.warning(
+                "Session file %s not found while fetching available reactions", session_file
+            )
+            return None
+
+    client = Client(
+        name=session_name,
+        api_id=API_ID,
+        api_hash=API_HASH,
+    )
+
+    try:
+        async with client:
+            return await _query(client)
+    except Exception:
+        logging.exception(
+            "Failed to fetch available reactions for session %s", session
+        )
+        return None
+
+
 async def add_reaction_emojis(message: Message, state: FSMContext) -> None:
     data, _, account = await _load_account_data(state)
 
@@ -2098,7 +2188,44 @@ async def add_reaction_emojis(message: Message, state: FSMContext) -> None:
             await _prompt_reaction_emojis(message, state)
             return
 
-        emoji_list = unique_emojis
+        session_name = data.get("account")
+        chat_id = data.get("reaction_channel_id")
+        available_emojis = await _get_available_quick_reaction_emojis(
+            message.from_user.id,
+            str(session_name) if isinstance(session_name, str) else None,
+            int(chat_id) if isinstance(chat_id, int) else None,
+        )
+
+        if available_emojis is not None:
+            filtered = [emoji for emoji in unique_emojis if emoji in available_emojis]
+            invalid = [emoji for emoji in unique_emojis if emoji not in available_emojis]
+
+            available_text = " ".join(sorted(available_emojis)) if available_emojis else "нет доступных реакций"
+
+            if not filtered:
+                await bot.send_message(
+                    message.from_user.id,
+                    (
+                        "Ни один из указанных эмодзи недоступен для быстрых реакций.\n"
+                        f"Доступные реакции: {available_text}."
+                    ),
+                )
+                await _prompt_reaction_emojis(message, state)
+                return
+
+            if invalid:
+                invalid_text = " ".join(invalid)
+                await bot.send_message(
+                    message.from_user.id,
+                    (
+                        "Следующие эмодзи недоступны и будут пропущены: "
+                        f"{invalid_text}.\nДоступные реакции: {available_text}."
+                    ),
+                )
+
+            emoji_list = filtered
+        else:
+            emoji_list = unique_emojis
 
     await state.update_data({"reaction_emojis": emoji_list, "apply_reactions_to_all": False})
 

--- a/test_settings_save.py
+++ b/test_settings_save.py
@@ -362,3 +362,55 @@ async def test_discussion_settings_dash_keeps_previous(monkeypatch):
 
     await main.add_discussion_reply_prompt(DummyMessage("off", user_id), state)
     assert state._data["discussion_reply_prompt"] is None
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reaction_emojis_rejects_unsupported(monkeypatch):
+    user_id = 77
+    state_data = {"account": "79991110000", "account_id": 900}
+    state = DummyState(state_data)
+    account_info = {"reaction_emojis": None}
+
+    sent_messages: list[tuple[int, str]] = []
+    reprompt_called = False
+    save_calls = 0
+
+    async def fake_load_account_data(dummy_state):  # noqa: ANN001
+        return state_data, state_data["account_id"], account_info
+
+    async def fake_send_message(chat_id: int, text: str, **kwargs):  # noqa: ANN001
+        sent_messages.append((chat_id, text))
+        return types.SimpleNamespace(message_id=1)
+
+    async def fake_prompt_reaction_emojis(message, dummy_state):  # noqa: ANN001
+        nonlocal reprompt_called
+        reprompt_called = True
+
+    async def fake_save_reaction_settings(message, dummy_state, *, finalize=True, notify=True):  # noqa: ANN001,ARG001
+        nonlocal save_calls
+        save_calls += 1
+
+    async def fake_get_available(user: int, session: str | None, chat_id: int | None = None):  # noqa: ANN001
+        assert user == user_id
+        assert session == state_data["account"]
+        assert chat_id is None
+        return {"🔥", "👍"}
+
+    monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+    monkeypatch.setattr(main, "_prompt_reaction_emojis", fake_prompt_reaction_emojis)
+    monkeypatch.setattr(main, "_save_reaction_settings", fake_save_reaction_settings)
+    monkeypatch.setattr(main, "_get_available_quick_reaction_emojis", fake_get_available)
+
+    await main.add_reaction_emojis(DummyMessage("😀 😎", user_id), state)
+
+    assert save_calls == 0, "Настройки не должны сохраняться при полностью неподдерживаемом вводе"
+    assert reprompt_called is True, "Пользователь должен получить повторный запрос"
+    assert "reaction_emojis" not in state._data, "Ввод не должен попадать в состояние"
+    assert any(
+        "Ни один из указанных эмодзи недоступен" in text for _, text in sent_messages
+    )
+    assert any(
+        "Доступные реакции:" in text and "🔥" in text and "👍" in text
+        for _, text in sent_messages
+    )


### PR DESCRIPTION
## Summary
- request available quick reactions from Telegram when editing reaction emoji settings and ignore unsupported emoji
- inform the user when invalid emoji are entered and prompt again if none are valid
- add a unit test covering the unsupported emoji flow

## Testing
- pytest test_settings_save.py

------
https://chatgpt.com/codex/tasks/task_e_68e2517ad6748330b57e344ab22b4af8