### PR TITLE
Adjust reaction emoji handler registration

### DIFF
--- a/main.py
+++ b/main.py
@@ -2066,7 +2066,6 @@ async def add_reaction_sleeps(message: Message, state: FSMContext) -> None:
     await state.set_state(reactionsettings.emojis)
 
 
-@dp.message(reactionsettings.emojis)
 def _extract_available_reaction_emojis(available: Any) -> Set[str]:
     result: Set[str] = set()
     if not available:
@@ -2157,6 +2156,7 @@ async def _get_available_quick_reaction_emojis(
         return None
 
 
+@dp.message(reactionsettings.emojis)
 async def add_reaction_emojis(message: Message, state: FSMContext) -> None:
     data, _, account = await _load_account_data(state)
 


### PR DESCRIPTION
## Summary
- move the reactionsettings.emojis dispatcher decorator from the helper to the add_reaction_emojis handler
- keep _extract_available_reaction_emojis as a plain helper so emoji input advances to the apply-all step

## Testing
- pytest test_settings_save.py::test_reaction_settings_flow_saves_values test_settings_save.py::test_reaction_settings_apply_all_triggers_bulk test_settings_save.py::test_reaction_settings_flow_with_defaults

------
https://chatgpt.com/codex/tasks/task_e_68e258d885708330a6bc97be8dfe8b21