### PR TITLE
Handle session shutdown race in check_account

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,6 +168,10 @@ active_pyrogram_clients: Dict[str, Client] = {}
 active_client_locks: Dict[str, asyncio.Lock] = {}
 
 
+CHECK_ACCOUNT_SHUTDOWN_TIMEOUT = 5.0
+CHECK_ACCOUNT_SHUTDOWN_INTERVAL = 0.2
+
+
 def _is_discussion_reply_message(message: Any) -> bool:
     reply = getattr(message, "reply_to_message", None)
     if not reply:
@@ -819,21 +823,49 @@ async def check_account(user_id, phone):
     key = make_session_key(user_id, phone)
     existing_client = active_pyrogram_clients.get(key)
 
-    if active_sessions.get(key) and existing_client:
+    if existing_client:
         lock = active_client_locks.setdefault(key, asyncio.Lock())
+        should_cleanup_lock = False
         async with lock:
-            if not getattr(existing_client, "is_connected", False):
-                await bot.send_message(user_id, f"Аккаунт {phone} сейчас используется, попробуйте позже")
-                return False
+            session_active = active_sessions.get(key)
+            is_connected = getattr(existing_client, "is_connected", False)
 
-            try:
-                await existing_client.get_me()
-                return True
-            except sqlite3.OperationalError as e:
-                if "database is locked" in str(e).lower():
-                    await bot.send_message(user_id, f"Аккаунт {phone} сейчас используется, попробуйте позже")
+            if session_active:
+                if not is_connected:
+                    await bot.send_message(
+                        user_id, f"Аккаунт {phone} сейчас используется, попробуйте позже"
+                    )
                     return False
-                raise
+
+                try:
+                    await existing_client.get_me()
+                    return True
+                except sqlite3.OperationalError as e:
+                    if "database is locked" in str(e).lower():
+                        await bot.send_message(
+                            user_id, f"Аккаунт {phone} сейчас используется, попробуйте позже"
+                        )
+                        return False
+                    raise
+
+            if is_connected and not session_active:
+                loop = asyncio.get_running_loop()
+                deadline = loop.time() + CHECK_ACCOUNT_SHUTDOWN_TIMEOUT
+                while getattr(existing_client, "is_connected", False):
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        await bot.send_message(user_id, f"Аккаунт {phone} останавливается")
+                        return False
+                    await asyncio.sleep(min(CHECK_ACCOUNT_SHUTDOWN_INTERVAL, remaining))
+
+                is_connected = getattr(existing_client, "is_connected", False)
+
+            if not session_active and not is_connected:
+                should_cleanup_lock = True
+
+        if should_cleanup_lock:
+            active_pyrogram_clients.pop(key, None)
+            active_client_locks.pop(key, None)
 
     client = Client(
         name=f"sessions/{user_id}/{phone}",

--- a/test_check_account.py
+++ b/test_check_account.py
@@ -1,0 +1,57 @@
+import os
+from typing import Any
+
+import pytest
+
+os.environ.setdefault("API_ID", "1")
+os.environ.setdefault("API_HASH", "test")
+os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
+
+import main  # noqa: E402
+
+
+class _DummyClient:
+    def __init__(self) -> None:
+        self.is_connected = True
+
+    async def get_me(self) -> Any:  # pragma: no cover - not used but keeps interface
+        return {"id": 1}
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_check_account_waits_for_existing_client_shutdown(monkeypatch):
+    user_id = 123
+    phone = "+79990000000"
+    key = main.make_session_key(user_id, phone)
+
+    main.active_sessions.pop(key, None)
+    main.active_pyrogram_clients[key] = _DummyClient()
+    main.active_client_locks.pop(key, None)
+
+    sent_messages: list[tuple[int, str]] = []
+
+    async def fake_send_message(uid: int, text: str, **kwargs: Any) -> None:
+        sent_messages.append((uid, text))
+
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+    monkeypatch.setattr(main, "CHECK_ACCOUNT_SHUTDOWN_TIMEOUT", 0.05)
+    monkeypatch.setattr(main, "CHECK_ACCOUNT_SHUTDOWN_INTERVAL", 0.01)
+
+    class ForbiddenClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - ensures no instantiation
+            raise AssertionError("Client should not be created while shutdown is pending")
+
+    monkeypatch.setattr(main, "Client", ForbiddenClient)
+
+    result = await main.check_account(user_id, phone)
+
+    assert result is False
+    assert sent_messages == [(user_id, f"Аккаунт {phone} останавливается")]
+
+    main.active_pyrogram_clients.pop(key, None)
+    main.active_client_locks.pop(key, None)


### PR DESCRIPTION
## Summary
- wait for existing Pyrogram clients to disconnect before creating a new one in `check_account`
- send a user notification when an account is still shutting down and clean up inactive client state
- add a regression test that simulates a connected client after `active_sessions` cleanup

## Testing
- pytest test_check_account.py

------
https://chatgpt.com/codex/tasks/task_e_68e27db541c08330a3db44f5fa746753