### PR TITLE
Handle reactions when comment chance fails

### DIFF
--- a/main.py
+++ b/main.py
@@ -303,54 +303,63 @@ async def _handle_linked_channel_message(
         return current_last_reaction_at
 
     try:
+        comment_sent = False
+        post_base_link: Optional[str] = None
+
         roll = random.randint(1, 100)
         if roll > comment_chance:
-            await bot.send_message(log_channel, f'Аккаунт {session} пропустил комментарий (rnd {roll} > {comment_chance})')
+            await bot.send_message(
+                log_channel,
+                f'Аккаунт {session} пропустил комментарий (rnd {roll} > {comment_chance})'
+            )
             await add_comment_log(
                 account_id,
                 channel=str(getattr(getattr(message, "chat", None), "id", "")),
                 message_id=getattr(message, "id", None),
-                status='skipped',
+                status='comment_skipped',
                 error=f'random {roll} > chance {comment_chance}',
             )
-            return current_last_reaction_at
+        else:
+            if is_quiet_period():
+                if key not in quiet_sessions_notified:
+                    await bot.send_message(
+                        log_channel,
+                        f'Аккаунт {session} приостановлен до {QUIET_END_MSK_STR} МСК (циркадный режим)'
+                    )
+                    quiet_sessions_notified.add(key)
+                return current_last_reaction_at
 
-        if is_quiet_period():
-            if key not in quiet_sessions_notified:
-                await bot.send_message(
-                    log_channel,
-                    f'Аккаунт {session} приостановлен до {QUIET_END_MSK_STR} МСК (циркадный режим)'
-                )
-                quiet_sessions_notified.add(key)
-            return current_last_reaction_at
+            await asyncio.sleep(random.uniform(xsleep, ysleep))
+            comment = generate_comment(post_text, comment_prompt)
+            msg = await client.send_message(message.chat.id, comment, reply_to_message_id=message.id)
 
-        await asyncio.sleep(random.uniform(xsleep, ysleep))
-        comment = generate_comment(post_text, comment_prompt)
-        msg = await client.send_message(message.chat.id, comment, reply_to_message_id=message.id)
-
-        post_base_link = _build_post_link(msg, message)
-        comment_link = f"{post_base_link}?comment={msg.id}"
-        await bot.send_message(
-            log_channel,
-            f'Аккаунт {session} отправил комментарий\n{comment_link}'
-        )
-        # Небольшая пауза перед записью в БД
-        await asyncio.sleep(0.2)
-        await add_comment_log(
-            account_id,
-            channel=str(message.chat.id),
-            message_id=msg.id,
-            status='success',
-        )
+            post_base_link = _build_post_link(msg, message)
+            comment_link = f"{post_base_link}?comment={msg.id}"
+            await bot.send_message(
+                log_channel,
+                f'Аккаунт {session} отправил комментарий\n{comment_link}'
+            )
+            # Небольшая пауза перед записью в БД
+            await asyncio.sleep(0.2)
+            await add_comment_log(
+                account_id,
+                channel=str(message.chat.id),
+                message_id=msg.id,
+                status='success',
+            )
+            comment_sent = True
 
         if (
             reactions_enabled
             and reaction_emojis
             and (selected_reaction_chance or 0) > 0
         ):
+            if post_base_link is None:
+                post_base_link = _build_post_link(message, message)
             channel_for_reactions = str(getattr(getattr(message, "chat", None), "id", ""))
             message_id = getattr(message, "id", None)
             limit = reaction_limit_per_message
+            status_suffix = '' if comment_sent else '_no_comment'
 
             if limit is not None:
                 if limit <= 0:
@@ -359,7 +368,7 @@ async def _handle_linked_channel_message(
                         account_id,
                         channel=channel_for_reactions,
                         message_id=message_id,
-                        status='reaction_skipped',
+                        status=f'reaction_skipped{status_suffix}',
                         error=f'reaction limit {limit} reached',
                     )
                     return current_last_reaction_at
@@ -371,7 +380,7 @@ async def _handle_linked_channel_message(
                             account_id,
                             channel=channel_for_reactions,
                             message_id=message_id,
-                            status='reaction_skipped',
+                            status=f'reaction_skipped{status_suffix}',
                             error=f'reaction limit {reaction_count}/{limit}',
                         )
                         return current_last_reaction_at
@@ -393,7 +402,7 @@ async def _handle_linked_channel_message(
                                 account_id,
                                 channel=str(message.chat.id),
                                 message_id=message.id,
-                                status='reaction_skipped',
+                                status=f'reaction_skipped{status_suffix}',
                                 error=(
                                     'reaction cooldown '
                                     f"{int((now - previous).total_seconds())}/{cooldown_seconds}s"
@@ -413,7 +422,7 @@ async def _handle_linked_channel_message(
                         account_id,
                         channel=str(message.chat.id),
                         message_id=message.id,
-                        status='reaction_success',
+                        status=f'reaction_success{status_suffix}',
                     )
                 except Exception as reaction_error:
                     await bot.send_message(
@@ -425,7 +434,7 @@ async def _handle_linked_channel_message(
                         account_id,
                         channel=str(message.chat.id),
                         message_id=message.id,
-                        status='reaction_error',
+                        status=f'reaction_error{status_suffix}',
                         error=str(reaction_error),
                     )
             else:
@@ -434,7 +443,7 @@ async def _handle_linked_channel_message(
                     account_id,
                     channel=str(message.chat.id),
                     message_id=message.id,
-                    status='reaction_skipped',
+                    status=f'reaction_skipped{status_suffix}',
                     error=f'reaction random {reaction_roll} > chance {selected_reaction_chance}',
                 )
 

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -679,3 +679,115 @@ async def test_reaction_occurs_after_cooldown(monkeypatch):
     assert updated_reactions
     assert result is not None
     assert result > previous_reaction
+
+
+@pytest.mark.anyio
+async def test_reaction_happens_when_comment_skipped(monkeypatch):
+    userid = 123
+    session = "+100500"
+    account_id = 42
+
+    original_active_sessions = dict(main.active_sessions)
+    original_quiet = set(main.quiet_sessions_notified)
+
+    main.active_sessions.clear()
+    main.quiet_sessions_notified.clear()
+    key = main.make_session_key(userid, session)
+    main.active_sessions[key] = True
+
+    client = DummyClient()
+
+    chat = types.SimpleNamespace(id=-2000000000, permissions=None, type="supergroup")
+    from_user = types.SimpleNamespace(is_self=False)
+    message = types.SimpleNamespace(
+        chat=chat,
+        text="Original post",
+        caption=None,
+        id=111,
+        reply_to_message=None,
+        from_user=from_user,
+    )
+
+    bot_logs = []
+    comment_logs = []
+
+    async def fake_bot_send_message(chat_id, text):
+        bot_logs.append((chat_id, text))
+
+    async def fake_add_comment_log(*args, **kwargs):
+        comment_logs.append((args, kwargs))
+
+    def fail_generate_comment(*args, **kwargs):  # pragma: no cover - should not be used
+        raise AssertionError("generate_comment should not be called when comment is skipped")
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    async def fake_count_reactions(*args, **kwargs):
+        return 0
+
+    rolls = [50, 1]
+
+    def fake_randint(a, b):
+        return rolls.pop(0) if rolls else 1
+
+    def fake_uniform(a, b):
+        return 0
+
+    def fake_choice(seq):
+        return seq[0]
+
+    updated_reactions: list[tuple[int, datetime]] = []
+
+    async def fake_update_last_reaction_at(account, ts):
+        updated_reactions.append((account, ts))
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
+    monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
+    monkeypatch.setattr(main, "generate_comment", fail_generate_comment)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "count_reactions_for_message", fake_count_reactions)
+    monkeypatch.setattr(main.random, "randint", fake_randint)
+    monkeypatch.setattr(main.random, "uniform", fake_uniform)
+    monkeypatch.setattr(main.random, "choice", fake_choice)
+    monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
+
+    try:
+        result = await main._handle_linked_channel_message(
+            client,
+            message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=10,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥"],
+            reaction_chance=100,
+            reaction_discussion_chance=100,
+            discussion_reply_prompt="discussion",
+            discussion_reply_chance=100,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=5,
+            reactions_enabled=True,
+            last_reaction_at=None,
+        )
+    finally:
+        main.active_sessions.clear()
+        main.active_sessions.update(original_active_sessions)
+        main.quiet_sessions_notified.clear()
+        main.quiet_sessions_notified.update(original_quiet)
+
+    assert result is not None
+    assert client.sent_messages == []
+    assert client.sent_reactions == [(message.chat.id, message.id, "🔥")]
+    statuses = [kwargs.get("status") for _, kwargs in comment_logs]
+    assert "comment_skipped" in statuses
+    assert "reaction_success_no_comment" in statuses
+    assert updated_reactions
+    assert updated_reactions[-1][0] == account_id
+    assert updated_reactions[-1][1] == result


### PR DESCRIPTION
## Summary
- keep processing reaction logic even when the comment roll skips the reply
- record distinct comment and reaction statuses when no comment is sent
- add coverage ensuring reactions are still applied when the comment chance fails

## Testing
- pytest test_linked_discussion_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68e281268944833085450ef40789e00f