### PR TITLE
Fix reaction apply-all menu return

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, time, timezone, timedelta
 from typing import Dict, List, Optional, Set, Any, Union, Tuple
+from types import SimpleNamespace
 import random
 import re
 from pyrogram import Client, filters
@@ -1155,6 +1156,7 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
             state,
             finalize=True,
             notify=False,
+            user_id=callback_query.from_user.id,
         )
         return
 
@@ -2317,16 +2319,24 @@ async def finish_reaction_settings(message: Message, state: FSMContext) -> None:
 
 
 async def _save_reaction_settings(
-    message: Message, state: FSMContext, *, finalize: bool = True, notify: bool = True
+    message: Message,
+    state: FSMContext,
+    *,
+    finalize: bool = True,
+    notify: bool = True,
+    user_id: Optional[int] = None,
 ) -> None:
     data, account_id, _ = await _load_account_data(state)
     session = data.get("account") if data else None
 
     chat = getattr(message, "chat", None)
     chat_id = getattr(chat, "id", None)
-    if chat_id is None:
-        from_user = getattr(message, "from_user", None)
-        chat_id = getattr(from_user, "id", None)
+    from_user = getattr(message, "from_user", None)
+    message_user_id = getattr(from_user, "id", None)
+    target_user_id = user_id if user_id is not None else message_user_id
+
+    if chat_id is None and target_user_id is not None:
+        chat_id = target_user_id
 
     if not account_id:
         if chat_id is not None:
@@ -2366,8 +2376,10 @@ async def _save_reaction_settings(
 
     if data.get("apply_reactions_to_all"):
         bulk_kwargs = dict(update_kwargs)
+        bulk_user_id = target_user_id if target_user_id is not None else chat_id
+        if bulk_user_id is not None:
+            await bulk_update_reaction_settings(bulk_user_id, **bulk_kwargs)
         if chat_id is not None:
-            await bulk_update_reaction_settings(chat_id, **bulk_kwargs)
             await bot.send_message(
                 chat_id,
                 "Настройки реакций применены ко всем вашим аккаунтам.",
@@ -2388,7 +2400,10 @@ async def _save_reaction_settings(
 
     if finalize:
         await state.clear()
-        await main_message(message)
+        if target_user_id is not None:
+            await main_message(SimpleNamespace(from_user=SimpleNamespace(id=target_user_id)))
+        else:
+            await main_message(message)
 
 
 def _parse_sleep_range_input(text: str) -> Optional[Tuple[int, int]]:

--- a/test_settings_save.py
+++ b/test_settings_save.py
@@ -326,6 +326,73 @@ async def test_reaction_apply_all_notifies_user_from_bot_message(monkeypatch):
 
 
 @pytest.mark.anyio("asyncio")
+async def test_reaction_apply_all_returns_main_menu_to_real_user(monkeypatch):
+    user_id = 501
+    bot_id = 1000001
+    state_data = {
+        "account": "79991119911",
+        "account_id": 991,
+        "reaction_limit_set": True,
+        "reaction_limit": 3,
+        "reaction_chance": 65,
+        "reaction_discussion_chance": 15,
+        "discussion_reply_chance": 5,
+        "discussion_reply_prompt": "Ответ",
+        "reaction_sleeps": "2-4",
+        "reaction_emojis": ["🔥"],
+        "apply_reactions_to_all": True,
+    }
+    state = DummyState(state_data)
+    account_info: dict[str, object] = {}
+
+    captured_updates: list[tuple[int, dict[str, object]]] = []
+    captured_bulk: list[tuple[int, dict[str, object]]] = []
+    sent_messages: list[tuple[int, str]] = []
+    captured_main_messages: list[object] = []
+
+    async def fake_load_account_data(dummy_state):  # noqa: ANN001
+        return state_data, state_data["account_id"], account_info
+
+    async def fake_update_account_settings(account_id: int, **kwargs):  # noqa: ANN001
+        captured_updates.append((account_id, kwargs))
+
+    async def fake_bulk_update(user: int, **kwargs):  # noqa: ANN001
+        captured_bulk.append((user, kwargs))
+
+    async def fake_send_message(chat_id: int, text: str, **kwargs):  # noqa: ANN001
+        sent_messages.append((chat_id, text))
+        return types.SimpleNamespace(message_id=1)
+
+    async def fake_main_message(message):  # noqa: ANN001
+        captured_main_messages.append(message)
+
+    monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
+    monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
+    monkeypatch.setattr(main, "bulk_update_reaction_settings", fake_bulk_update)
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+    monkeypatch.setattr(main, "main_message", fake_main_message)
+
+    class DummyCallback:
+        def __init__(self) -> None:
+            self.data = "reaction_apply_all"
+            self.from_user = types.SimpleNamespace(id=user_id)
+            self.message = DummyMessage("", user_id, from_user_id=bot_id, chat_id=user_id)
+
+        async def answer(self, *args, **kwargs):  # noqa: ANN001
+            return None
+
+    await main.callbacks(DummyCallback(), state)
+
+    assert captured_updates and captured_updates[0][0] == state_data["account_id"]
+    assert captured_bulk and captured_bulk[0][0] == user_id
+    assert any(chat_id == user_id for chat_id, _ in sent_messages)
+    assert state.cleared is True
+    assert captured_main_messages, "Главное меню должно быть показано пользователю"
+    returned_message = captured_main_messages[-1]
+    assert getattr(getattr(returned_message, "from_user", None), "id", None) == user_id
+
+
+@pytest.mark.anyio("asyncio")
 async def test_reaction_settings_flow_with_defaults(monkeypatch):
     user_id = 43
     state_data = {"account": "79995550000", "account_id": 321}


### PR DESCRIPTION
## Summary
- ensure reaction apply-all callbacks pass the acting user id into the settings saver so notifications and menu refresh target the requester
- update reaction settings persistence to reuse the user id for bulk updates and to reopen the main menu for the correct user
- add a regression test covering the apply-all flow returning the main menu to the user without errors

## Testing
- pytest test_settings_save.py -k reaction_apply_all


------
https://chatgpt.com/codex/tasks/task_e_68e2858b42ec8330aec2b6aac08e94bd