### PR TITLE
Aggregate skip logs before notifying

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import shutil
 import sqlite3
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import datetime, time, timezone, timedelta
 from typing import Dict, List, Optional, Set, Any, Union, Tuple
@@ -168,6 +169,16 @@ quiet_sessions_notified: Set[str] = set()
 active_pyrogram_clients: Dict[str, Client] = {}
 active_client_locks: Dict[str, asyncio.Lock] = {}
 
+skip_log_counters: Dict[str, Counter] = defaultdict(Counter)
+skip_log_last_reasons: Dict[str, Dict[str, str]] = defaultdict(dict)
+skip_log_last_flush_at: Optional[datetime] = None
+
+SKIP_LOG_FLUSH_INTERVAL_SECONDS = 600
+SKIP_LOG_EVENT_LABELS = {
+    "comment": "Комментарии",
+    "reaction": "Реакции",
+}
+
 
 CHECK_ACCOUNT_SHUTDOWN_TIMEOUT = 5.0
 CHECK_ACCOUNT_SHUTDOWN_INTERVAL = 0.2
@@ -232,6 +243,72 @@ def _build_post_link(sent_message: Any, original_message: Any) -> str:
     chat = getattr(original_message, "chat", None)
     chat_id = getattr(chat, "id", "")
     return f'https://t.me/c/{str(chat_id).replace("-", "")}/{getattr(original_message, "id", "")}'
+
+
+def enqueue_skip_log(session: str, event_type: str, reason: str) -> None:
+    """Adds skip statistics for delayed aggregated reporting."""
+
+    counters = skip_log_counters[session]
+    counters[event_type] += 1
+    skip_log_last_reasons[session][event_type] = reason
+
+
+async def flush_skip_logs() -> None:
+    """Sends an aggregated skip report and resets collected data."""
+
+    global skip_log_last_flush_at
+
+    entries: List[Tuple[str, str, int, Optional[str]]] = []
+    for session, counters in skip_log_counters.items():
+        for event_type, count in counters.items():
+            if count <= 0:
+                continue
+            reason = skip_log_last_reasons.get(session, {}).get(event_type)
+            entries.append((session, event_type, count, reason))
+
+    now = datetime.now(timezone.utc)
+
+    if not entries:
+        skip_log_last_flush_at = now
+        return
+
+    timestamp = now.strftime('%H:%M:%S')
+    lines = [f"🕒 Сводка пропусков ({timestamp} UTC)"]
+
+    grouped: Dict[str, List[Tuple[str, int, Optional[str]]]] = defaultdict(list)
+    for session, event_type, count, reason in entries:
+        grouped[session].append((event_type, count, reason))
+
+    for session in sorted(grouped):
+        lines.append(f"Аккаунт {session}:")
+        for event_type, count, reason in sorted(grouped[session], key=lambda item: item[0]):
+            label = SKIP_LOG_EVENT_LABELS.get(event_type, event_type)
+            reason_suffix = f" (последняя причина: {reason})" if reason else ""
+            lines.append(f"• {label}: {count}{reason_suffix}")
+
+    message = "\n".join(lines)
+
+    try:
+        await bot.send_message(log_channel, message)
+    except Exception:
+        logging.exception("Не удалось отправить сводку пропусков")
+    finally:
+        skip_log_counters.clear()
+        skip_log_last_reasons.clear()
+        skip_log_last_flush_at = now
+
+
+async def skip_log_flush_worker() -> None:
+    """Background task that periodically flushes skip statistics."""
+
+    while True:
+        try:
+            await asyncio.sleep(SKIP_LOG_FLUSH_INTERVAL_SECONDS)
+            await flush_skip_logs()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logging.exception("Ошибка фоновой отправки сводки пропусков")
 
 
 async def _handle_linked_channel_message(
@@ -313,12 +390,10 @@ async def _handle_linked_channel_message(
         if roll > comment_chance:
             comment_skipped = True
             comment_skip_reason = f'random {roll} > chance {comment_chance}'
-            await bot.send_message(
-                log_channel,
-                (
-                    f'Аккаунт {session} пропустил комментарий '
-                    f'(rnd {roll} > {comment_chance}), проверяем реакцию'
-                ),
+            enqueue_skip_log(
+                session,
+                "comment",
+                f"{comment_skip_reason}; проверяем реакцию",
             )
             await add_comment_log(
                 account_id,
@@ -375,9 +450,10 @@ async def _handle_linked_channel_message(
             if limit is not None:
                 if limit <= 0:
                     reason = f'reaction limit {limit} reached'
-                    await bot.send_message(
-                        log_channel,
-                        f'Аккаунт {session} пропустил реакцию: {reason}{reaction_comment_context}'
+                    enqueue_skip_log(
+                        session,
+                        "reaction",
+                        f"{reason}{reaction_comment_context}",
                     )
                     await asyncio.sleep(0.2)
                     await add_comment_log(
@@ -392,9 +468,10 @@ async def _handle_linked_channel_message(
                     reaction_count = await count_reactions_for_message(channel_for_reactions, message_id)
                     if reaction_count >= limit:
                         reason = f'reaction limit {reaction_count}/{limit}'
-                        await bot.send_message(
-                            log_channel,
-                            f'Аккаунт {session} пропустил реакцию: {reason}{reaction_comment_context}'
+                        enqueue_skip_log(
+                            session,
+                            "reaction",
+                            f"{reason}{reaction_comment_context}",
                         )
                         await asyncio.sleep(0.2)
                         await add_comment_log(
@@ -422,9 +499,10 @@ async def _handle_linked_channel_message(
                                 'reaction cooldown '
                                 f"{int((now - previous).total_seconds())}/{cooldown_seconds}s"
                             )
-                            await bot.send_message(
-                                log_channel,
-                                f'Аккаунт {session} пропустил реакцию: {reason}{reaction_comment_context}'
+                            enqueue_skip_log(
+                                session,
+                                "reaction",
+                                f"{reason}{reaction_comment_context}",
                             )
                             await asyncio.sleep(0.2)
                             await add_comment_log(
@@ -470,9 +548,10 @@ async def _handle_linked_channel_message(
                 reason = (
                     f'reaction random {reaction_roll} > chance {selected_reaction_chance}'
                 )
-                await bot.send_message(
-                    log_channel,
-                    f'Аккаунт {session} пропустил реакцию: {reason}{reaction_comment_context}'
+                enqueue_skip_log(
+                    session,
+                    "reaction",
+                    f"{reason}{reaction_comment_context}",
                 )
                 await asyncio.sleep(0.2)
                 await add_comment_log(
@@ -3926,9 +4005,10 @@ async def main():
                     log_file.flush()
             
             asyncio.create_task(process_warmup_accounts())
+            asyncio.create_task(skip_log_flush_worker())
             log_file.write("Starting bot polling...\n")
             log_file.flush()
-            
+
             await dp.start_polling(bot)
     except Exception as e:
         with open("bot_error.txt", "w") as error_file:

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -754,6 +754,9 @@ async def test_reaction_happens_when_comment_skipped(monkeypatch):
     monkeypatch.setattr(main, "is_quiet_period", lambda: False)
     monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
 
+    main.skip_log_counters.clear()
+    main.skip_log_last_reasons.clear()
+
     try:
         result = await main._handle_linked_channel_message(
             client,
@@ -776,16 +779,21 @@ async def test_reaction_happens_when_comment_skipped(monkeypatch):
             reactions_enabled=True,
             last_reaction_at=None,
         )
+        comment_counter = main.skip_log_counters.get(session)
+        assert comment_counter is not None
+        assert comment_counter["comment"] == 1
+        assert "проверяем реакцию" in main.skip_log_last_reasons[session]["comment"]
     finally:
         main.active_sessions.clear()
         main.active_sessions.update(original_active_sessions)
         main.quiet_sessions_notified.clear()
         main.quiet_sessions_notified.update(original_quiet)
+        main.skip_log_counters.clear()
+        main.skip_log_last_reasons.clear()
 
     assert result is not None
     assert client.sent_messages == []
     assert client.sent_reactions == [(message.chat.id, message.id, "🔥")]
-    assert any("пропустил комментарий" in log[1] for log in bot_logs)
     assert any("поставил реакцию" in log[1] for log in bot_logs)
     statuses = [kwargs.get("status") for _, kwargs in comment_logs]
     assert "comment_skipped" in statuses

--- a/test_skip_logs.py
+++ b/test_skip_logs.py
@@ -1,0 +1,56 @@
+import os
+
+import pytest
+
+os.environ.setdefault("API_ID", "1")
+os.environ.setdefault("API_HASH", "hash")
+os.environ.setdefault("BOT_TOKEN", "123456:TEST")
+
+import main
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def reset_skip_logs():
+    main.skip_log_counters.clear()
+    main.skip_log_last_reasons.clear()
+    main.skip_log_last_flush_at = None
+    yield
+    main.skip_log_counters.clear()
+    main.skip_log_last_reasons.clear()
+    main.skip_log_last_flush_at = None
+
+
+@pytest.mark.anyio
+async def test_flush_skip_logs_sends_aggregated_summary(monkeypatch):
+    sent_messages = []
+
+    async def fake_send_message(chat_id, text):
+        sent_messages.append((chat_id, text))
+
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+
+    main.enqueue_skip_log("+100500", "comment", "reason1")
+    main.enqueue_skip_log("+100500", "comment", "reason2")
+    main.enqueue_skip_log("+100500", "reaction", "reaction_reason")
+    main.enqueue_skip_log("+200600", "reaction", "other_reason")
+
+    await main.flush_skip_logs()
+
+    assert len(sent_messages) == 1
+    _, message = sent_messages[0]
+
+    assert "Сводка пропусков" in message
+    assert "+100500" in message
+    assert "Комментарии: 2" in message
+    assert "reason2" in message  # последняя причина для комментариев
+    assert "Реакции: 1" in message
+    assert "+200600" in message
+
+    assert main.skip_log_counters == {}
+    assert main.skip_log_last_reasons == {}
+    assert main.skip_log_last_flush_at is not None


### PR DESCRIPTION
## Summary
- add data structures and helpers to accumulate skip reasons and flush them on a schedule
- replace direct skip notifications in the linked channel handler with the new helper and run a background flusher
- cover the helper with a new test and update the linked discussion handler test to check aggregated logging

## Testing
- pytest test_skip_logs.py test_linked_discussion_handler.py::test_discussion_reply_from_user_triggers_comment_and_reaction
- pytest test_linked_discussion_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68e28c69959883309344edd961f3b26e