### PR TITLE
Add periodic comment log cleanup

### DIFF
--- a/db.py
+++ b/db.py
@@ -944,6 +944,20 @@ async def count_reactions_for_message(channel: str, message_id: int) -> int:
     return int(row["reaction_count"] or 0)
 
 
+async def cleanup_comment_logs(retention_days: int = 2) -> int:
+    """Remove comment log entries older than the specified number of days."""
+
+    conn = await _require_conn()
+    cursor = await conn.execute(
+        "DELETE FROM comment_logs WHERE created_at < datetime('now', ?)",
+        (f"-{retention_days} day",),
+    )
+    await conn.commit()
+    deleted = cursor.rowcount if cursor.rowcount is not None else 0
+    await cursor.close()
+    return max(deleted, 0)
+
+
 async def get_global_statistics() -> Dict[str, Any]:
     """Aggregate high-level metrics for accounts, comments and warmup channels."""
 

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ from db import (
     delete_account,
     ensure_account,
     ensure_user,
+    cleanup_comment_logs,
     ensure_warmup_settings,
     get_account_by_id,
     get_account_by_session,
@@ -180,6 +181,10 @@ SKIP_LOG_EVENT_LABELS = {
 }
 
 
+COMMENT_LOG_RETENTION_DAYS = 2
+COMMENT_LOG_CLEANUP_INTERVAL_SECONDS = 6 * 60 * 60
+
+
 CHECK_ACCOUNT_SHUTDOWN_TIMEOUT = 5.0
 CHECK_ACCOUNT_SHUTDOWN_INTERVAL = 0.2
 
@@ -309,6 +314,20 @@ async def skip_log_flush_worker() -> None:
             raise
         except Exception:
             logging.exception("Ошибка фоновой отправки сводки пропусков")
+
+
+async def comment_log_cleanup_worker() -> None:
+    """Periodically remove outdated comment log entries."""
+
+    while True:
+        try:
+            await asyncio.sleep(COMMENT_LOG_CLEANUP_INTERVAL_SECONDS)
+            deleted = await cleanup_comment_logs(COMMENT_LOG_RETENTION_DAYS)
+            logging.info("Удалено устаревших записей comment_logs: %d", deleted)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logging.exception("Ошибка очистки журнала комментариев")
 
 
 async def _handle_linked_channel_message(
@@ -3967,7 +3986,14 @@ async def main():
             await ensure_latest_warmup_settings(force=True)
             log_file.write("Database initialized successfully\n")
             log_file.flush()
-            
+
+            deleted_logs = await cleanup_comment_logs(COMMENT_LOG_RETENTION_DAYS)
+            logging.info("Удалено устаревших записей comment_logs при запуске: %d", deleted_logs)
+            log_file.write(
+                f"Removed {deleted_logs} outdated comment log entries at startup\\n"
+            )
+            log_file.flush()
+
             await bot.delete_webhook(drop_pending_updates=True)
             log_file.write("Webhook deleted\n")
             log_file.flush()
@@ -4003,9 +4029,10 @@ async def main():
                     await mark_account_stopped(account["id"])
                     log_file.write(f"Stopped account {phone} - no session file\n")
                     log_file.flush()
-            
+
             asyncio.create_task(process_warmup_accounts())
             asyncio.create_task(skip_log_flush_worker())
+            asyncio.create_task(comment_log_cleanup_worker())
             log_file.write("Starting bot polling...\n")
             log_file.flush()
 

--- a/test_comment_log_cleanup.py
+++ b/test_comment_log_cleanup.py
@@ -1,0 +1,74 @@
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+os.environ.setdefault("API_ID", "1")
+os.environ.setdefault("API_HASH", "hash")
+os.environ.setdefault("BOT_TOKEN", "123456:TEST")
+
+import db
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def setup_database(tmp_path):
+    database_path = tmp_path / "test.sqlite3"
+    os.environ["DATABASE_URL"] = f"sqlite:///{database_path}"
+    await db.close_db()
+    await db.init_db()
+    try:
+        yield
+    finally:
+        await db.close_db()
+
+
+@pytest.mark.anyio
+async def test_cleanup_comment_logs_removes_outdated_entries():
+    await db.ensure_user(1)
+    account = await db.ensure_account(1, "+100500", "session.session")
+
+    conn = await db._require_conn()
+    now = datetime.utcnow().replace(microsecond=0)
+    entries = [
+        (now - timedelta(days=5), 1),
+        (now - timedelta(days=3), 2),
+        (now - timedelta(days=2), 3),
+        (now - timedelta(days=1), 4),
+    ]
+
+    for created_at, message_id in entries:
+        await conn.execute(
+            """
+            INSERT INTO comment_logs (account_id, channel, message_id, status, error, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                account["id"],
+                "test_channel",
+                message_id,
+                "test_status",
+                None,
+                created_at.strftime("%Y-%m-%d %H:%M:%S"),
+            ),
+        )
+    await conn.commit()
+
+    deleted = await db.cleanup_comment_logs(retention_days=2)
+    assert deleted == 2
+
+    async with conn.execute(
+        "SELECT message_id, created_at FROM comment_logs ORDER BY message_id"
+    ) as cursor:
+        remaining_rows = await cursor.fetchall()
+
+    remaining_message_ids = [row["message_id"] for row in remaining_rows]
+    assert remaining_message_ids == [3, 4]
+
+    remaining_dates = [datetime.strptime(row["created_at"], "%Y-%m-%d %H:%M:%S") for row in remaining_rows]
+    cutoff = now - timedelta(days=2)
+    assert all(cutoff <= date <= now for date in remaining_dates)


### PR DESCRIPTION
## Summary
- add a database helper to delete comment logs older than the retention window
- schedule a background worker in the bot to clean up comment logs and log the result at startup
- add a unit test that verifies only outdated comment log entries are removed

## Testing
- pytest test_comment_log_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68e290cc9b9c833087ab36fbac998a87