### PR TITLE
Move management buttons to reply keyboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,13 @@ import re
 from pyrogram import Client, filters
 from pyrogram.errors import ChatWriteForbidden, UserAlreadyParticipant
 from aiogram import Bot, Dispatcher, types
-from aiogram.types import Message, InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.types import (
+    Message,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    KeyboardButton,
+    ReplyKeyboardMarkup,
+)
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.filters import CommandStart, Command
 from aiogram.fsm.context import FSMContext
@@ -1090,17 +1096,62 @@ async def main_message(message):
         if not is_running:
             builder.row(button_delete)
 
-
-    builder.row(
-        types.InlineKeyboardButton(text="Добавить аккаунт", callback_data="add_account"),
-        types.InlineKeyboardButton(text="Добавить прогрев", callback_data="add_warmup"),
-    )
-    builder.row(
-        types.InlineKeyboardButton(text="📊 Общая статистика", callback_data="global_stats"),
-        types.InlineKeyboardButton(text="⚙️ Настройки прогрева", callback_data="warmup_settings"),
-    )
-
     await bot.send_message(message.from_user.id, 'Ваши аккаунты', reply_markup=builder.as_markup())
+    await bot.send_message(
+        message.from_user.id,
+        "Доступные действия",
+        reply_markup=build_main_actions_keyboard(),
+    )
+
+
+def build_main_actions_keyboard() -> ReplyKeyboardMarkup:
+    """Возвращает клавиатуру с основными действиями под строкой ввода."""
+
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [
+                KeyboardButton(text="Добавить аккаунт"),
+                KeyboardButton(text="Добавить прогрев"),
+            ],
+            [
+                KeyboardButton(text="📊 Общая статистика"),
+                KeyboardButton(text="⚙️ Настройки прогрева"),
+            ],
+        ],
+        resize_keyboard=True,
+    )
+
+
+async def start_add_account_flow(user_id: int, state: FSMContext, *, warmup_only: bool = False) -> None:
+    """Запускает сценарий добавления аккаунта или назначения прогрева."""
+
+    await state.clear()
+    await bot.send_message(user_id, 'Пришлите номер телефона\nПример: 79999999999')
+    await state.set_state(addsession.number)
+    await state.update_data({"warmup_only": warmup_only})
+
+
+async def open_warmup_settings_dialog(user_id: int, state: FSMContext) -> None:
+    """Открывает диалог редактирования общих настроек прогрева."""
+
+    await state.clear()
+    settings = await refresh_warmup_settings_from_db()
+    prompt = (
+        f"{format_warmup_settings(settings)}\n\n"
+        "Введите новый лимит вступлений в день (число) или '-' чтобы оставить без изменений."
+    )
+    await bot.send_message(user_id, prompt)
+    await state.set_state(warmupsettings.limit)
+
+
+async def send_global_stats_report(user_id: int) -> None:
+    """Отправляет пользователю и в лог-канал сводку по всем аккаунтам."""
+
+    stats = await get_global_statistics()
+    report = format_global_statistics_report(stats)
+    await bot.send_message(user_id, report, parse_mode="Markdown")
+    if user_id != log_channel:
+        await bot.send_message(log_channel, report, parse_mode="Markdown")
 
 
 
@@ -1145,6 +1196,44 @@ async def show_account_summary(message: types.Message, state: FSMContext):
     
     # Показываем резюме
     await send_account_summary_to_user(message.from_user.id, account['id'], phone)
+
+
+@dp.message(lambda message: message.text == "Добавить аккаунт")
+async def handle_add_account_button(message: types.Message, state: FSMContext):
+    if not await is_user_authenticated(message.from_user.id):
+        await message.answer("Сначала авторизуйтесь командой /start")
+        return
+
+    await start_add_account_flow(message.from_user.id, state, warmup_only=False)
+
+
+@dp.message(lambda message: message.text == "Добавить прогрев")
+async def handle_add_warmup_button(message: types.Message, state: FSMContext):
+    if not await is_user_authenticated(message.from_user.id):
+        await message.answer("Сначала авторизуйтесь командой /start")
+        return
+
+    await start_add_account_flow(message.from_user.id, state, warmup_only=True)
+
+
+@dp.message(lambda message: message.text == "📊 Общая статистика")
+async def handle_global_stats_button(message: types.Message, state: FSMContext):  # noqa: ARG001
+    if not await is_user_authenticated(message.from_user.id):
+        await message.answer("Сначала авторизуйтесь командой /start")
+        return
+
+    await send_global_stats_report(message.from_user.id)
+    await main_message(message)
+
+
+@dp.message(lambda message: message.text == "⚙️ Настройки прогрева")
+async def handle_warmup_settings_button(message: types.Message, state: FSMContext):
+    if not await is_user_authenticated(message.from_user.id):
+        await message.answer("Сначала авторизуйтесь командой /start")
+        return
+
+    await open_warmup_settings_dialog(message.from_user.id, state)
+
 
 @dp.message(Command("testwarmup"))
 async def test_warmup_command(message: Message) -> None:
@@ -1261,35 +1350,20 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
     await callback_query.message.delete()
 
     if call == 'add_account':
-        await bot.send_message(callback_query.from_user.id, 'Пришлите номер телефона\nПример: 79999999999')
-        await state.set_state(addsession.number)
+        await start_add_account_flow(callback_query.from_user.id, state, warmup_only=False)
 
     elif call == 'add_warmup':
-        await state.clear()
-        await bot.send_message(callback_query.from_user.id, 'Пришлите номер телефона для прогрева\nПример: 79999999999')
-        await state.set_state(addsession.number)
-        await state.update_data({"warmup_only": True})
+        await start_add_account_flow(callback_query.from_user.id, state, warmup_only=True)
 
 
     elif call == 'warmup_settings':
         await callback_query.answer()
-        await state.clear()
-        settings = await refresh_warmup_settings_from_db()
-        prompt = (
-            f"{format_warmup_settings(settings)}\n\n"
-            "Введите новый лимит вступлений в день (число) или '-' чтобы оставить без изменений."
-        )
-        await bot.send_message(callback_query.from_user.id, prompt)
-        await state.set_state(warmupsettings.limit)
+        await open_warmup_settings_dialog(callback_query.from_user.id, state)
         return
 
     elif call == 'global_stats':
         await callback_query.answer()
-        stats = await get_global_statistics()
-        report = format_global_statistics_report(stats)
-        await bot.send_message(callback_query.from_user.id, report, parse_mode="Markdown")
-        if callback_query.from_user.id != log_channel:
-            await bot.send_message(log_channel, report, parse_mode="Markdown")
+        await send_global_stats_report(callback_query.from_user.id)
         await main_message(callback_query)
         return
 

--- a/test_main_keyboard_layout.py
+++ b/test_main_keyboard_layout.py
@@ -58,16 +58,17 @@ async def test_main_menu_keyboard_layout_no_accounts(monkeypatch):
     async def fake_ensure_account(user_id: int, phone: str, session_path: str):  # noqa: ARG001
         return None
 
-    sent: dict[str, object] = {}
+    sent_messages: list[dict[str, object]] = []
 
     async def fake_send_message(chat_id: int, text: str, reply_markup=None, **kwargs):  # noqa: ANN001
-        sent.update({
+        payload = {
             "chat_id": chat_id,
             "text": text,
             "markup": reply_markup,
             "kwargs": kwargs,
-        })
-        return types.SimpleNamespace(message_id=1)
+        }
+        sent_messages.append(payload)
+        return types.SimpleNamespace(message_id=len(sent_messages))
 
     monkeypatch.setattr(main.os.path, "isdir", fake_isdir)
     monkeypatch.setattr(main.os, "makedirs", fake_makedirs)
@@ -80,23 +81,25 @@ async def test_main_menu_keyboard_layout_no_accounts(monkeypatch):
 
     await main.main_message(DummyMessage(user_id))
 
-    markup = sent.get("markup")
-    assert markup is not None, "Ожидается, что главное меню отправляется пользователю"
+    assert len(sent_messages) == 2, "Должны отправляться сообщения с аккаунтами и с клавиатурой действий"
 
-    rows = markup.inline_keyboard
-    assert len(rows) == 2, "Без аккаунтов должно быть две строки действий"
+    account_message, actions_message = sent_messages
 
-    add_row = rows[0]
-    assert [button.callback_data for button in add_row] == ["add_account", "add_warmup"], (
-        "Первый ряд должен содержать кнопки добавления аккаунта и прогрева"
+    account_markup = account_message.get("markup")
+    assert isinstance(account_markup, main.InlineKeyboardMarkup), (
+        "Первое сообщение должно содержать inline-клавиатуру с аккаунтами"
     )
+    assert account_message["text"] == "Ваши аккаунты"
+    assert account_markup.inline_keyboard == [], "Без аккаунтов inline-клавиатура должна быть пустой"
 
-    bottom_row = rows[1]
-    assert [button.callback_data for button in bottom_row] == ["global_stats", "warmup_settings"], (
-        "Нижний ряд должен содержать сервисные кнопки статистики и настроек"
-    )
-    assert bottom_row[0].text == "📊 Общая статистика"
-    assert bottom_row[1].text == "⚙️ Настройки прогрева"
+    actions_markup = actions_message.get("markup")
+    assert actions_message["text"] == "Доступные действия"
+    assert isinstance(actions_markup, main.ReplyKeyboardMarkup), "Ожидается reply-клавиатура действий"
+    keyboard_layout = [[button.text for button in row] for row in actions_markup.keyboard]
+    assert keyboard_layout == [
+        ["Добавить аккаунт", "Добавить прогрев"],
+        ["📊 Общая статистика", "⚙️ Настройки прогрева"],
+    ]
 
 
 @pytest.mark.anyio
@@ -141,18 +144,17 @@ async def test_main_menu_keyboard_layout_with_account_shows_reaction_button(monk
     async def fake_ensure_account(user_id: int, phone: str, session_path: str):  # noqa: ARG001
         return None
 
-    sent: dict[str, object] = {}
+    sent_messages: list[dict[str, object]] = []
 
     async def fake_send_message(chat_id: int, text: str, reply_markup=None, **kwargs):  # noqa: ANN001
-        sent.update(
-            {
-                "chat_id": chat_id,
-                "text": text,
-                "markup": reply_markup,
-                "kwargs": kwargs,
-            }
-        )
-        return types.SimpleNamespace(message_id=1)
+        payload = {
+            "chat_id": chat_id,
+            "text": text,
+            "markup": reply_markup,
+            "kwargs": kwargs,
+        }
+        sent_messages.append(payload)
+        return types.SimpleNamespace(message_id=len(sent_messages))
 
     monkeypatch.setattr(main.os.path, "isdir", fake_isdir)
     monkeypatch.setattr(main.os, "makedirs", fake_makedirs)
@@ -166,8 +168,12 @@ async def test_main_menu_keyboard_layout_with_account_shows_reaction_button(monk
 
     await main.main_message(DummyMessage(user_id))
 
-    markup = sent.get("markup")
-    assert markup is not None, "Главное меню должно содержать клавиатуру"
+    assert len(sent_messages) == 2, "Должны отправляться сообщения с аккаунтами и действиями"
+
+    account_message, actions_message = sent_messages
+
+    markup = account_message.get("markup")
+    assert markup is not None, "Главное меню должно содержать inline-клавиатуру"
 
     reaction_buttons = [
         button
@@ -177,3 +183,7 @@ async def test_main_menu_keyboard_layout_with_account_shows_reaction_button(monk
     ]
     assert reaction_buttons, "Для аккаунта должна появиться кнопка настроек реакций"
     assert reaction_buttons[0].text == "🎯 Реакции на посты и ответы"
+
+    actions_markup = actions_message.get("markup")
+    assert actions_message["text"] == "Доступные действия"
+    assert isinstance(actions_markup, main.ReplyKeyboardMarkup)


### PR DESCRIPTION
## Summary
- move add/statistics controls to a persistent reply keyboard and keep inline buttons for account actions
- reuse shared helpers for starting account/warmup flows and opening global stats/settings dialogs
- update the keyboard layout tests to cover the new reply keyboard message

## Testing
- pytest test_main_keyboard_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68e27b990d38833080179f8db1dc6a9c