### PR TITLE
Handle quick reaction availability for linked channel messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 import random
 import re
 from pyrogram import Client, filters
-from pyrogram.errors import ChatWriteForbidden, UserAlreadyParticipant
+from pyrogram.errors import ChatWriteForbidden, ReactionInvalid, UserAlreadyParticipant
 from aiogram import Bot, Dispatcher, types
 from aiogram.types import (
     Message,
@@ -175,6 +175,8 @@ active_account_ids: Dict[str, int] = {}
 quiet_sessions_notified: Set[str] = set()
 active_pyrogram_clients: Dict[str, Client] = {}
 active_client_locks: Dict[str, asyncio.Lock] = {}
+
+_chat_available_reactions_cache: Dict[int, Set[str]] = {}
 
 skip_log_counters: Dict[str, Counter] = defaultdict(Counter)
 skip_log_last_reasons: Dict[str, Dict[str, str]] = defaultdict(dict)
@@ -510,8 +512,47 @@ async def _handle_linked_channel_message(
 
             reaction_roll = random.randint(1, 100)
             if reaction_roll <= (selected_reaction_chance or 0):
+                chat_obj = getattr(message, "chat", None)
+                chat_id_for_reactions = getattr(chat_obj, "id", None)
+                working_reaction_emojis = list(reaction_emojis)
+                allowed_reaction_emojis = await _get_chat_available_quick_reactions(
+                    client,
+                    chat_id_for_reactions,
+                )
+                if allowed_reaction_emojis is not None:
+                    working_reaction_emojis = [
+                        emoji for emoji in working_reaction_emojis if emoji in allowed_reaction_emojis
+                    ]
+
+                if not working_reaction_emojis:
+                    available_text: Optional[str] = None
+                    if allowed_reaction_emojis is not None:
+                        available_text = (
+                            " ".join(sorted(allowed_reaction_emojis))
+                            if allowed_reaction_emojis
+                            else "none"
+                        )
+                    reason = "no allowed quick reactions"
+                    if available_text is not None:
+                        reason = f"{reason} (available: {available_text})"
+
+                    enqueue_skip_log(
+                        session,
+                        "reaction",
+                        f"{reason}{reaction_comment_context}",
+                    )
+                    await asyncio.sleep(0.2)
+                    await add_comment_log(
+                        account_id,
+                        channel=str(getattr(getattr(message, "chat", None), "id", "")),
+                        message_id=message.id,
+                        status=f'reaction_skipped{status_suffix}',
+                        error=reason,
+                    )
+                    return current_last_reaction_at
+
                 await asyncio.sleep(random.uniform(reaction_sleep_min, reaction_sleep_max))
-                reaction_emoji = random.choice(reaction_emojis)
+                reaction_emoji = random.choice(working_reaction_emojis)
                 try:
                     now = datetime.now(timezone.utc)
                     previous = current_last_reaction_at
@@ -552,10 +593,57 @@ async def _handle_linked_channel_message(
                     await asyncio.sleep(0.2)
                     await add_comment_log(
                         account_id,
-                        channel=str(message.chat.id),
+                        channel=str(getattr(getattr(message, "chat", None), "id", "")),
                         message_id=message.id,
                         status=f'reaction_success{status_suffix}',
                     )
+                except ReactionInvalid as reaction_error:
+                    refreshed_allowed = await _get_chat_available_quick_reactions(
+                        client,
+                        chat_id_for_reactions,
+                        force_refresh=True,
+                    )
+                    invalid_emojis: Set[str] = set()
+                    if refreshed_allowed is not None:
+                        invalid_emojis = {
+                            emoji
+                            for emoji in working_reaction_emojis
+                            if emoji not in refreshed_allowed
+                        }
+                        working_reaction_emojis = [
+                            emoji
+                            for emoji in working_reaction_emojis
+                            if emoji in refreshed_allowed
+                        ]
+                    else:
+                        invalid_emojis = set(working_reaction_emojis)
+                        working_reaction_emojis = []
+
+                    invalid_text = " ".join(sorted(invalid_emojis)) if invalid_emojis else str(reaction_emoji)
+                    reason = (
+                        f"reaction invalid for emoji {reaction_emoji}: "
+                        f"unsupported emojis {invalid_text}"
+                    )
+                    logging.warning(
+                        "Reaction invalid for chat %s with emojis %s: %s",
+                        chat_id_for_reactions,
+                        invalid_text,
+                        reaction_error,
+                    )
+                    enqueue_skip_log(
+                        session,
+                        "reaction",
+                        f"{reason}{reaction_comment_context}",
+                    )
+                    await asyncio.sleep(0.2)
+                    await add_comment_log(
+                        account_id,
+                        channel=str(getattr(getattr(message, "chat", None), "id", "")),
+                        message_id=message.id,
+                        status=f'reaction_skipped{status_suffix}',
+                        error=reason,
+                    )
+                    return current_last_reaction_at
                 except Exception as reaction_error:
                     await bot.send_message(
                         log_channel,
@@ -2336,6 +2424,41 @@ def _extract_available_reaction_emojis(available: Any) -> Set[str]:
             result.add(emoji_value)
 
     return result
+
+
+async def _get_chat_available_quick_reactions(
+    client: Client,
+    chat_id: Optional[int],
+    *,
+    force_refresh: bool = False,
+) -> Optional[Set[str]]:
+    if chat_id is None:
+        return None
+
+    if force_refresh:
+        _chat_available_reactions_cache.pop(chat_id, None)
+    else:
+        cached = _chat_available_reactions_cache.get(chat_id)
+        if cached is not None:
+            return cached
+
+    if not hasattr(client, "get_available_reactions"):
+        return None
+
+    try:
+        try:
+            available = await client.get_available_reactions(chat_id)
+        except TypeError:
+            available = await client.get_available_reactions()
+    except Exception:
+        logging.exception(
+            "Failed to fetch available reactions for chat %s", chat_id
+        )
+        return None
+
+    allowed = _extract_available_reaction_emojis(available)
+    _chat_available_reactions_cache[chat_id] = allowed
+    return allowed
 
 
 async def _get_available_quick_reaction_emojis(

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -15,6 +15,7 @@ class DummyClient:
     def __init__(self):
         self.sent_messages = []
         self.sent_reactions = []
+        self.available_reactions = [types.SimpleNamespace(emoji="🔥")]
 
     async def send_message(self, chat_id, text, reply_to_message_id=None):
         self.sent_messages.append((chat_id, text, reply_to_message_id))
@@ -27,10 +28,24 @@ class DummyClient:
     async def send_reaction(self, chat_id, message_id, emoji):
         self.sent_reactions.append((chat_id, message_id, emoji))
 
+    async def get_available_reactions(self, chat_id=None):
+        return self.available_reactions
+
 
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def clear_reaction_cache():
+    original_cache = dict(main._chat_available_reactions_cache)
+    main._chat_available_reactions_cache.clear()
+    try:
+        yield
+    finally:
+        main._chat_available_reactions_cache.clear()
+        main._chat_available_reactions_cache.update(original_cache)
 
 
 @pytest.mark.anyio
@@ -220,6 +235,112 @@ async def test_discussion_reply_from_user_triggers_comment_and_reaction(monkeypa
     assert "success" in statuses
     assert "reaction_success" in statuses
     assert len(updated_reactions) == 1
+
+
+@pytest.mark.anyio
+async def test_reaction_skipped_when_not_in_allowed_set(monkeypatch):
+    userid = 123
+    session = "+100500"
+    account_id = 42
+
+    original_active_sessions = dict(main.active_sessions)
+    original_quiet = set(main.quiet_sessions_notified)
+
+    main.active_sessions.clear()
+    main.quiet_sessions_notified.clear()
+    key = main.make_session_key(userid, session)
+    main.active_sessions[key] = True
+
+    client = DummyClient()
+    client.available_reactions = [types.SimpleNamespace(emoji="👍")]
+
+    chat = types.SimpleNamespace(id=-2000000000, permissions=None, type="supergroup")
+    from_user = types.SimpleNamespace(is_self=False)
+    message = types.SimpleNamespace(
+        chat=chat,
+        text="Channel post",
+        caption=None,
+        id=111,
+        reply_to_message=None,
+        from_user=from_user,
+    )
+
+    comment_logs = []
+    skip_logs = []
+
+    async def fake_bot_send_message(*args, **kwargs):
+        return None
+
+    async def fake_add_comment_log(*args, **kwargs):
+        comment_logs.append((args, kwargs))
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    async def fake_count_reactions(*args, **kwargs):
+        return 0
+
+    def fake_randint(a, b):
+        return 1
+
+    def fake_uniform(a, b):
+        return 0
+
+    async def fake_update_last_reaction_at(*args, **kwargs):
+        return None
+
+    def fake_enqueue_skip_log(session_name, event_type, message_text):
+        skip_logs.append((session_name, event_type, message_text))
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
+    monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "count_reactions_for_message", fake_count_reactions)
+    monkeypatch.setattr(main.random, "randint", fake_randint)
+    monkeypatch.setattr(main.random, "uniform", fake_uniform)
+    monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
+    monkeypatch.setattr(main, "enqueue_skip_log", fake_enqueue_skip_log)
+
+    try:
+        await main._handle_linked_channel_message(
+            client,
+            message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=0,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥"],
+            reaction_chance=100,
+            reaction_discussion_chance=100,
+            discussion_reply_prompt="discussion",
+            discussion_reply_chance=100,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=5,
+            reactions_enabled=True,
+            last_reaction_at=None,
+        )
+    finally:
+        main.active_sessions.clear()
+        main.active_sessions.update(original_active_sessions)
+        main.quiet_sessions_notified.clear()
+        main.quiet_sessions_notified.update(original_quiet)
+
+    assert not client.sent_reactions, "Реакция не должна отправляться при отсутствии доступных эмодзи"
+    assert skip_logs, "Должен быть записан пропуск реакции"
+    assert any("no allowed quick reactions" in entry[2] for entry in skip_logs)
+
+    reaction_statuses = [kwargs.get("status") for _, kwargs in comment_logs]
+    assert any(status and status.startswith("reaction_skipped") for status in reaction_statuses)
+    assert any(
+        "no allowed quick reactions" in kwargs.get("error", "")
+        for _, kwargs in comment_logs
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- cache available quick reactions per chat and filter configured emojis before sending
- handle ReactionInvalid errors by refreshing allowed reactions and logging skips instead of retrying
- extend linked discussion handler tests with cache reset fixture and a scenario where reactions are skipped when disallowed

## Testing
- pytest test_linked_discussion_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68e2db1f7c488330a62bc2f2157936e5