### PR TITLE
Add manual skip summary trigger and adjust flushing

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,6 +188,8 @@ SKIP_LOG_EVENT_LABELS = {
     "reaction": "Реакции",
 }
 
+SKIP_SUMMARY_BUTTON_TEXT = "🕒 Сводка пропусков (лог-канал)"
+
 
 COMMENT_LOG_RETENTION_DAYS = 2
 COMMENT_LOG_CLEANUP_INTERVAL_SECONDS = 6 * 60 * 60
@@ -1205,6 +1207,9 @@ def build_main_actions_keyboard() -> ReplyKeyboardMarkup:
                 KeyboardButton(text="📊 Общая статистика"),
                 KeyboardButton(text="⚙️ Настройки прогрева"),
             ],
+            [
+                KeyboardButton(text=SKIP_SUMMARY_BUTTON_TEXT),
+            ],
         ],
         resize_keyboard=True,
     )
@@ -1311,6 +1316,22 @@ async def handle_global_stats_button(message: types.Message, state: FSMContext):
         return
 
     await send_global_stats_report(message.from_user.id)
+    await flush_skip_logs()
+    await main_message(message)
+
+
+@dp.message(lambda message: message.text == SKIP_SUMMARY_BUTTON_TEXT)
+async def handle_skip_summary_button(message: types.Message, state: FSMContext):  # noqa: ARG001
+    if not await is_user_authenticated(message.from_user.id):
+        await message.answer("Сначала авторизуйтесь командой /start")
+        return
+
+    if not skip_log_counters:
+        await message.answer("Сводка пропусков пуста, в лог-канал ничего не отправлено.")
+    else:
+        await message.answer("Сводка пропусков отправлена в лог-канал.")
+
+    await flush_skip_logs()
     await main_message(message)
 
 
@@ -4228,7 +4249,6 @@ async def main():
                     log_file.flush()
 
             asyncio.create_task(process_warmup_accounts())
-            asyncio.create_task(skip_log_flush_worker())
             asyncio.create_task(comment_log_cleanup_worker())
             log_file.write("Starting bot polling...\n")
             log_file.flush()
@@ -4247,4 +4267,3 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
     # asyncio.run(bot.run())
-

--- a/test_skip_logs.py
+++ b/test_skip_logs.py
@@ -1,5 +1,7 @@
 import os
 
+from types import SimpleNamespace
+
 import pytest
 
 os.environ.setdefault("API_ID", "1")
@@ -54,3 +56,46 @@ async def test_flush_skip_logs_sends_aggregated_summary(monkeypatch):
     assert main.skip_log_counters == {}
     assert main.skip_log_last_reasons == {}
     assert main.skip_log_last_flush_at is not None
+
+
+class DummyMessage:
+    def __init__(self, user_id: int, text: str):
+        self.from_user = SimpleNamespace(id=user_id)
+        self.text = text
+        self.answers = []
+
+    async def answer(self, text, **kwargs):  # noqa: D401, ANN001
+        self.answers.append(text)
+
+
+@pytest.mark.anyio
+async def test_skip_summary_requires_manual_trigger(monkeypatch):
+    sent_messages = []
+
+    async def fake_send_message(chat_id, text, **kwargs):  # noqa: D401, ANN001
+        sent_messages.append((chat_id, text))
+
+    async def fake_is_user_authenticated(user_id):  # noqa: D401, ANN001
+        return True
+
+    async def fake_main_message(message):  # noqa: D401, ANN001, ARG001
+        return None
+
+    monkeypatch.setattr(main.bot, "send_message", fake_send_message)
+    monkeypatch.setattr(main, "is_user_authenticated", fake_is_user_authenticated)
+    monkeypatch.setattr(main, "main_message", fake_main_message)
+
+    main.enqueue_skip_log("+100500", "comment", "reason1")
+
+    assert sent_messages == []  # Ничего не отправлено автоматически
+
+    message = DummyMessage(user_id=1, text=main.SKIP_SUMMARY_BUTTON_TEXT)
+
+    await main.handle_skip_summary_button(message, SimpleNamespace())
+
+    assert message.answers == ["Сводка пропусков отправлена в лог-канал."]
+    assert len(sent_messages) == 1
+
+    chat_id, text = sent_messages[0]
+    assert chat_id == main.log_channel
+    assert "Сводка пропусков" in text


### PR DESCRIPTION
## Summary
- expose a manual "Сводка пропусков" action in the main keyboard and handler that flushes logs only to the log channel
- invoke skip log flushing from the global stats handler and remove the automatic background worker
- extend skip log tests to cover manual triggering behaviour

## Testing
- pytest test_skip_logs.py

------
https://chatgpt.com/codex/tasks/task_e_68e2dd5ba9f883308547fb2c5f34b315