### PR TITLE
НАДО РАЗОБРАТЬСЯ.. МОЖЕТ ТУТ ИНТЕРЕСНАЯ ЛОГИКА Improve reaction retry resilience

### DIFF
--- a/main.py
+++ b/main.py
@@ -121,6 +121,7 @@ WARMUP_VERBOSE_NOTIFICATIONS = _get_bool_env("WARMUP_VERBOSE_NOTIFICATIONS", def
 
 DEFAULT_REACTION_LIMIT_PER_MESSAGE = _get_int_env("REACTION_LIMIT_PER_MESSAGE")
 REACTION_MIN_INTERVAL_SECONDS = _get_int_env("REACTION_MIN_INTERVAL_SECONDS") or 0
+REACTION_RETRY_DELAY_SECONDS = 2
 
 # Инициализация бота
 bot = Bot(token=BOT_TOKEN)
@@ -554,18 +555,102 @@ async def _handle_linked_channel_message(
                     return current_last_reaction_at
 
                 await asyncio.sleep(random.uniform(reaction_sleep_min, reaction_sleep_max))
-                reaction_emoji = random.choice(working_reaction_emojis)
-                try:
-                    now = datetime.now(timezone.utc)
-                    previous = current_last_reaction_at
-                    if previous is not None and previous.tzinfo is None:
-                        previous = previous.replace(tzinfo=timezone.utc)
-                    cooldown_seconds = REACTION_MIN_INTERVAL_SECONDS
-                    if previous is not None and cooldown_seconds:
-                        if now - previous < timedelta(seconds=cooldown_seconds):
+                max_reaction_attempts = 3
+                retry_delay_seconds = REACTION_RETRY_DELAY_SECONDS
+                reaction_sent = False
+                last_reaction_exception: Optional[Exception] = None
+                last_reaction_attempt = 0
+
+                for reaction_attempt in range(1, max_reaction_attempts + 1):
+                    if not working_reaction_emojis:
+                        break
+
+                    last_reaction_attempt = reaction_attempt
+                    reaction_emoji = random.choice(working_reaction_emojis)
+                    try:
+                        now = datetime.now(timezone.utc)
+                        previous = current_last_reaction_at
+                        if previous is not None and previous.tzinfo is None:
+                            previous = previous.replace(tzinfo=timezone.utc)
+                        cooldown_seconds = REACTION_MIN_INTERVAL_SECONDS
+                        if previous is not None and cooldown_seconds:
+                            if now - previous < timedelta(seconds=cooldown_seconds):
+                                reason = (
+                                    'reaction cooldown '
+                                    f"{int((now - previous).total_seconds())}/{cooldown_seconds}s"
+                                )
+                                enqueue_skip_log(
+                                    session,
+                                    "reaction",
+                                    f"{reason}{reaction_comment_context}",
+                                )
+                                await asyncio.sleep(0.2)
+                                await add_comment_log(
+                                    account_id,
+                                    channel=str(message.chat.id),
+                                    message_id=message.id,
+                                    status=f'reaction_skipped{status_suffix}',
+                                    error=reason,
+                                )
+                                return current_last_reaction_at
+
+                        await client.send_reaction(message.chat.id, message.id, reaction_emoji)
+                        await bot.send_message(
+                            log_channel,
+                            (
+                                f'Аккаунт {session} поставил реакцию {reaction_emoji}'
+                                f'{reaction_comment_context}\n{post_base_link}'
+                            ),
+                        )
+                        await update_last_reaction_at(account_id, now)
+                        current_last_reaction_at = now
+                        await asyncio.sleep(0.2)
+                        await add_comment_log(
+                            account_id,
+                            channel=str(getattr(getattr(message, "chat", None), "id", "")),
+                            message_id=message.id,
+                            status=f'reaction_success{status_suffix}',
+                        )
+                        reaction_sent = True
+                        break
+                    except ReactionInvalid as reaction_error:
+                        last_reaction_exception = reaction_error
+                        logging.warning(
+                            "Reaction invalid attempt %s/%s for chat %s: %s",
+                            reaction_attempt,
+                            max_reaction_attempts,
+                            chat_id_for_reactions,
+                            reaction_error,
+                        )
+                        remaining_candidates = [
+                            emoji for emoji in working_reaction_emojis if emoji != reaction_emoji
+                        ]
+                        refreshed_allowed = await _get_chat_available_quick_reactions(
+                            client,
+                            chat_id_for_reactions,
+                            force_refresh=True,
+                        )
+                        invalid_emojis: Set[str] = {reaction_emoji}
+                        if refreshed_allowed is not None:
+                            invalid_emojis.update(
+                                emoji for emoji in remaining_candidates if emoji not in refreshed_allowed
+                            )
+                            working_reaction_emojis = [
+                                emoji for emoji in remaining_candidates if emoji in refreshed_allowed
+                            ]
+                        else:
+                            invalid_emojis.update(remaining_candidates)
+                            working_reaction_emojis = []
+
+                        if not working_reaction_emojis:
+                            invalid_text = (
+                                " ".join(sorted(invalid_emojis))
+                                if invalid_emojis
+                                else str(reaction_emoji)
+                            )
                             reason = (
-                                'reaction cooldown '
-                                f"{int((now - previous).total_seconds())}/{cooldown_seconds}s"
+                                f"reaction invalid for emoji {reaction_emoji}: "
+                                f"unsupported emojis {invalid_text}"
                             )
                             enqueue_skip_log(
                                 session,
@@ -575,89 +660,63 @@ async def _handle_linked_channel_message(
                             await asyncio.sleep(0.2)
                             await add_comment_log(
                                 account_id,
-                                channel=str(message.chat.id),
+                                channel=str(getattr(getattr(message, "chat", None), "id", "")),
                                 message_id=message.id,
                                 status=f'reaction_skipped{status_suffix}',
                                 error=reason,
                             )
                             return current_last_reaction_at
 
-                    await client.send_reaction(message.chat.id, message.id, reaction_emoji)
-                    await bot.send_message(
-                        log_channel,
-                        (
-                            f'Аккаунт {session} поставил реакцию {reaction_emoji}'
-                            f'{reaction_comment_context}\n{post_base_link}'
+                        if reaction_attempt < max_reaction_attempts:
+                            await asyncio.sleep(retry_delay_seconds)
+                    except Exception as reaction_error:
+                        last_reaction_exception = reaction_error
+                        logging.warning(
+                            "Reaction attempt %s/%s failed for %s: %s",
+                            reaction_attempt,
+                            max_reaction_attempts,
+                            session,
+                            reaction_error,
                         )
-                    )
-                    await update_last_reaction_at(account_id, now)
-                    current_last_reaction_at = now
-                    await asyncio.sleep(0.2)
-                    await add_comment_log(
-                        account_id,
-                        channel=str(getattr(getattr(message, "chat", None), "id", "")),
-                        message_id=message.id,
-                        status=f'reaction_success{status_suffix}',
-                    )
-                except ReactionInvalid as reaction_error:
-                    refreshed_allowed = await _get_chat_available_quick_reactions(
-                        client,
-                        chat_id_for_reactions,
-                        force_refresh=True,
-                    )
-                    invalid_emojis: Set[str] = set()
-                    if refreshed_allowed is not None:
-                        invalid_emojis = {
-                            emoji
-                            for emoji in working_reaction_emojis
-                            if emoji not in refreshed_allowed
-                        }
                         working_reaction_emojis = [
-                            emoji
-                            for emoji in working_reaction_emojis
-                            if emoji in refreshed_allowed
+                            emoji for emoji in working_reaction_emojis if emoji != reaction_emoji
                         ]
-                    else:
-                        invalid_emojis = set(working_reaction_emojis)
-                        working_reaction_emojis = []
+                        if (
+                            reaction_attempt < max_reaction_attempts
+                            and working_reaction_emojis
+                        ):
+                            await asyncio.sleep(retry_delay_seconds)
 
-                    invalid_text = " ".join(sorted(invalid_emojis)) if invalid_emojis else str(reaction_emoji)
-                    reason = (
-                        f"reaction invalid for emoji {reaction_emoji}: "
-                        f"unsupported emojis {invalid_text}"
+                if not reaction_sent:
+                    exception_text = (
+                        str(last_reaction_exception)
+                        if last_reaction_exception
+                        else 'unknown error'
                     )
-                    logging.warning(
-                        "Reaction invalid for chat %s with emojis %s: %s",
-                        chat_id_for_reactions,
-                        invalid_text,
-                        reaction_error,
+                    failure_reason = (
+                        f"reaction error after {last_reaction_attempt or 0} attempts: "
+                        f"{exception_text}"
+                    )
+                    failure_reason_with_context = (
+                        f"{failure_reason}{reaction_comment_context}"
                     )
                     enqueue_skip_log(
                         session,
                         "reaction",
-                        f"{reason}{reaction_comment_context}",
+                        failure_reason_with_context,
                     )
-                    await asyncio.sleep(0.2)
-                    await add_comment_log(
-                        account_id,
-                        channel=str(getattr(getattr(message, "chat", None), "id", "")),
-                        message_id=message.id,
-                        status=f'reaction_skipped{status_suffix}',
-                        error=reason,
+                    error_message = (
+                        f'Аккаунт {session} ошибка при установке реакции: '
+                        f"{failure_reason_with_context}"
                     )
-                    return current_last_reaction_at
-                except Exception as reaction_error:
-                    await bot.send_message(
-                        log_channel,
-                        f'Аккаунт {session} ошибка при установке реакции: {reaction_error}'
-                    )
+                    await bot.send_message(log_channel, error_message)
                     await asyncio.sleep(0.2)
                     await add_comment_log(
                         account_id,
                         channel=str(message.chat.id),
                         message_id=message.id,
                         status=f'reaction_error{status_suffix}',
-                        error=str(reaction_error),
+                        error=failure_reason,
                     )
             else:
                 reason = (
@@ -676,6 +735,7 @@ async def _handle_linked_channel_message(
                     status=f'reaction_skipped{status_suffix}',
                     error=reason,
                 )
+
 
     except ChatWriteForbidden as e:
         await bot.send_message(log_channel, f'Аккаунт {session} не может оставить комментарий: {e}')

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -922,3 +922,284 @@ async def test_reaction_happens_when_comment_skipped(monkeypatch):
     assert updated_reactions
     assert updated_reactions[-1][0] == account_id
     assert updated_reactions[-1][1] == result
+
+
+@pytest.mark.anyio
+async def test_reaction_retries_transient_failure_until_success(monkeypatch):
+    userid = 123
+    session = "+100500"
+    account_id = 42
+
+    original_active_sessions = dict(main.active_sessions)
+    original_quiet = set(main.quiet_sessions_notified)
+
+    main.active_sessions.clear()
+    main.quiet_sessions_notified.clear()
+    key = main.make_session_key(userid, session)
+    main.active_sessions[key] = True
+
+    class RetryClient(DummyClient):
+        def __init__(self):
+            super().__init__()
+            self.available_reactions = [
+                types.SimpleNamespace(emoji="🔥"),
+                types.SimpleNamespace(emoji="❤️"),
+                types.SimpleNamespace(emoji="👍"),
+            ]
+            self.attempts = 0
+
+        async def send_reaction(self, chat_id, message_id, emoji):
+            self.sent_reactions.append((chat_id, message_id, emoji))
+            self.attempts += 1
+            if self.attempts < 3:
+                raise Exception(f"temporary failure {self.attempts}")
+
+    client = RetryClient()
+
+    chat = types.SimpleNamespace(id=-2000000000, permissions=None, type="supergroup")
+    reply_to_message = types.SimpleNamespace(
+        forward_from_chat=types.SimpleNamespace(username="source_channel"),
+        forward_from_message_id=321,
+    )
+    from_user = types.SimpleNamespace(is_self=False)
+    message = types.SimpleNamespace(
+        chat=chat,
+        text="Original post",
+        caption=None,
+        id=111,
+        reply_to_message=reply_to_message,
+        from_user=from_user,
+    )
+
+    bot_logs = []
+    comment_logs = []
+    sleep_calls = []
+
+    async def fake_bot_send_message(chat_id, text):
+        bot_logs.append((chat_id, text))
+
+    async def fake_add_comment_log(*args, **kwargs):
+        comment_logs.append((args, kwargs))
+
+    def fake_generate_comment(post_text, system_prompt):
+        return f"comment:{post_text}:{system_prompt}"
+
+    async def fake_sleep(duration):
+        sleep_calls.append(duration)
+
+    async def fake_count_reactions(*args, **kwargs):
+        return 0
+
+    def fake_randint(a, b):
+        return 1
+
+    def fake_uniform(a, b):
+        return 0
+
+    def fake_choice(seq):
+        return seq[0]
+
+    updated_reactions = []
+
+    async def fake_update_last_reaction_at(account, ts):
+        updated_reactions.append((account, ts))
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
+    monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
+    monkeypatch.setattr(main, "generate_comment", fake_generate_comment)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "count_reactions_for_message", fake_count_reactions)
+    monkeypatch.setattr(main.random, "randint", fake_randint)
+    monkeypatch.setattr(main.random, "uniform", fake_uniform)
+    monkeypatch.setattr(main.random, "choice", fake_choice)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
+    monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+
+    try:
+        await main._handle_linked_channel_message(
+            client,
+            message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=100,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥", "❤️", "👍"],
+            reaction_chance=100,
+            reaction_discussion_chance=100,
+            discussion_reply_prompt="prompt",
+            discussion_reply_chance=100,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=5,
+            reactions_enabled=True,
+            last_reaction_at=None,
+        )
+    finally:
+        main.active_sessions.clear()
+        main.active_sessions.update(original_active_sessions)
+        main.quiet_sessions_notified.clear()
+        main.quiet_sessions_notified.update(original_quiet)
+
+    assert [emoji for _, _, emoji in client.sent_reactions] == ["🔥", "❤️", "👍"]
+    assert any("поставил реакцию" in log[1] for log in bot_logs)
+    reaction_logs = [entry for entry in comment_logs if entry[1]["status"].startswith("reaction_")]
+    assert reaction_logs
+    assert reaction_logs == [reaction_logs[0]]
+    assert reaction_logs[0][1]["status"].startswith("reaction_success")
+    assert sleep_calls.count(main.REACTION_RETRY_DELAY_SECONDS) == 2
+    assert len(updated_reactions) == 1
+
+
+@pytest.mark.anyio
+async def test_reaction_retries_record_single_error(monkeypatch):
+    userid = 123
+    session = "+100500"
+    account_id = 42
+
+    original_active_sessions = dict(main.active_sessions)
+    original_quiet = set(main.quiet_sessions_notified)
+    original_skip_counters = {
+        key: counter.copy() for key, counter in main.skip_log_counters.items()
+    }
+    original_skip_reasons = {
+        key: dict(value) for key, value in main.skip_log_last_reasons.items()
+    }
+
+    main.active_sessions.clear()
+    main.quiet_sessions_notified.clear()
+    main.skip_log_counters.clear()
+    main.skip_log_last_reasons.clear()
+    key = main.make_session_key(userid, session)
+    main.active_sessions[key] = True
+
+    class AlwaysFailClient(DummyClient):
+        def __init__(self):
+            super().__init__()
+            self.available_reactions = [
+                types.SimpleNamespace(emoji="🔥"),
+                types.SimpleNamespace(emoji="❤️"),
+                types.SimpleNamespace(emoji="👍"),
+            ]
+            self.attempts = 0
+
+        async def send_reaction(self, chat_id, message_id, emoji):
+            self.sent_reactions.append((chat_id, message_id, emoji))
+            self.attempts += 1
+            raise Exception("permanent failure")
+
+    client = AlwaysFailClient()
+
+    chat = types.SimpleNamespace(id=-2000000000, permissions=None, type="supergroup")
+    reply_to_message = types.SimpleNamespace(
+        forward_from_chat=types.SimpleNamespace(username="source_channel"),
+        forward_from_message_id=321,
+    )
+    from_user = types.SimpleNamespace(is_self=False)
+    message = types.SimpleNamespace(
+        chat=chat,
+        text="Original post",
+        caption=None,
+        id=111,
+        reply_to_message=reply_to_message,
+        from_user=from_user,
+    )
+
+    bot_logs = []
+    comment_logs = []
+    sleep_calls = []
+
+    async def fake_bot_send_message(chat_id, text):
+        bot_logs.append((chat_id, text))
+
+    async def fake_add_comment_log(*args, **kwargs):
+        comment_logs.append((args, kwargs))
+
+    def fake_generate_comment(post_text, system_prompt):
+        return f"comment:{post_text}:{system_prompt}"
+
+    async def fake_sleep(duration):
+        sleep_calls.append(duration)
+
+    async def fake_count_reactions(*args, **kwargs):
+        return 0
+
+    def fake_randint(a, b):
+        return 1
+
+    def fake_uniform(a, b):
+        return 0
+
+    def fake_choice(seq):
+        return seq[0]
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
+    monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
+    monkeypatch.setattr(main, "generate_comment", fake_generate_comment)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "count_reactions_for_message", fake_count_reactions)
+    monkeypatch.setattr(main.random, "randint", fake_randint)
+    monkeypatch.setattr(main.random, "uniform", fake_uniform)
+    monkeypatch.setattr(main.random, "choice", fake_choice)
+    monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+
+    reaction_skip_counter = None
+    reaction_skip_reason = None
+
+    try:
+        await main._handle_linked_channel_message(
+            client,
+            message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=100,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥", "❤️", "👍"],
+            reaction_chance=100,
+            reaction_discussion_chance=100,
+            discussion_reply_prompt="prompt",
+            discussion_reply_chance=100,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=5,
+            reactions_enabled=True,
+            last_reaction_at=None,
+        )
+        counter = main.skip_log_counters.get(session)
+        if counter is not None:
+            reaction_skip_counter = counter.copy()
+        reaction_skip_reason = main.skip_log_last_reasons.get(session, {}).get(
+            "reaction"
+        )
+    finally:
+        main.active_sessions.clear()
+        main.active_sessions.update(original_active_sessions)
+        main.quiet_sessions_notified.clear()
+        main.quiet_sessions_notified.update(original_quiet)
+        main.skip_log_counters.clear()
+        for key, counter in original_skip_counters.items():
+            main.skip_log_counters[key] = counter.copy()
+        main.skip_log_last_reasons.clear()
+        for key, value in original_skip_reasons.items():
+            main.skip_log_last_reasons[key] = dict(value)
+
+    assert [emoji for _, _, emoji in client.sent_reactions] == ["🔥", "❤️", "👍"]
+    error_messages = [log for log in bot_logs if "ошибка при установке реакции" in log[1]]
+    assert len(error_messages) == 1
+    reaction_logs = [entry for entry in comment_logs if entry[1]["status"].startswith("reaction_")]
+    assert reaction_logs
+    assert reaction_logs == [reaction_logs[0]]
+    assert reaction_logs[0][1]["status"].startswith("reaction_error")
+    assert reaction_logs[0][1]["error"].startswith("reaction error after")
+    assert sleep_calls.count(main.REACTION_RETRY_DELAY_SECONDS) == 2
+    assert reaction_skip_counter is not None
+    assert reaction_skip_counter["reaction"] == 1
+    assert reaction_skip_reason is not None
+    assert "reaction error after" in reaction_skip_reason


### PR DESCRIPTION
## Summary
- retry channel reactions up to three times with a shared retry delay constant and filtered emoji candidates after invalid errors
- consolidate final reaction failure handling to log, notify, and persist a single aggregated error entry
- expand linked discussion handler tests to cover transient success, persistent failure logging, and to assert retry delays via the shared constant

## Testing
- `pytest test_linked_discussion_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68e2e09e0da083308d64fa67a7049ed8