### PR TITLE
Fix reaction log link for discussion comments

### DIFF
--- a/main.py
+++ b/main.py
@@ -618,11 +618,19 @@ async def _handle_linked_channel_message(
                                 return current_last_reaction_at
 
                         await client.send_reaction(message.chat.id, message.id, reaction_emoji)
+                        reaction_link = post_base_link
+                        if (
+                            reaction_link
+                            and _is_discussion_reply_message(message)
+                            and getattr(message, "id", None) is not None
+                        ):
+                            reaction_link = f"{reaction_link}?comment={message.id}"
+
                         await bot.send_message(
                             log_channel,
                             (
                                 f'Аккаунт {session} поставил реакцию {reaction_emoji}'
-                                f'{reaction_comment_context}\n{post_base_link}'
+                                f'{reaction_comment_context}\n{reaction_link}'
                             )
                         )
                         await update_last_reaction_at(account_id, now)


### PR DESCRIPTION
## Summary
- add comment-specific links for reactions to discussion messages so they open the correct comment

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e372e5e9c883309e2014145a742055