### PR TITLE
Handle reactions for replies detected via comment logs

### DIFF
--- a/db.py
+++ b/db.py
@@ -944,6 +944,34 @@ async def count_reactions_for_message(channel: str, message_id: int) -> int:
     return int(row["reaction_count"] or 0)
 
 
+async def has_successful_comment_log_entry(
+    account_id: int,
+    channel: Optional[str],
+    message_id: Optional[int],
+) -> bool:
+    """Return True if we previously stored a successful comment for the message."""
+
+    if channel is None or message_id is None:
+        return False
+
+    conn = await _require_conn()
+    async with conn.execute(
+        """
+        SELECT 1
+        FROM comment_logs
+        WHERE account_id = ?
+          AND channel = ?
+          AND message_id = ?
+          AND status = 'success'
+        LIMIT 1
+        """,
+        (account_id, channel, message_id),
+    ) as cursor:
+        row = await cursor.fetchone()
+
+    return row is not None
+
+
 async def cleanup_comment_logs(retention_days: int = 2) -> int:
     """Remove comment log entries older than the specified number of days."""
 

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ from db import (
     bulk_update_reaction_settings,
     count_reactions_for_message,
     db_update_warmup_schedule,
+    has_successful_comment_log_entry,
     delete_account,
     ensure_account,
     ensure_user,
@@ -227,6 +228,38 @@ def _is_reply_to_own_comment(message: Any) -> bool:
     if from_user and getattr(from_user, "is_self", False):
         return False
     return True
+
+
+async def _is_reply_to_account_comment(message: Any, account_id: int) -> bool:
+    """Check whether message replies to a comment previously sent by the account."""
+
+    if _is_reply_to_own_comment(message):
+        return True
+
+    reply = getattr(message, "reply_to_message", None)
+    if not reply:
+        return False
+
+    reply_message_id = getattr(reply, "id", None)
+    if reply_message_id is None:
+        return False
+
+    chat = getattr(message, "chat", None)
+    channel_id = getattr(chat, "id", None)
+    if channel_id is None:
+        return False
+
+    channel_for_lookup = str(channel_id)
+
+    try:
+        return await has_successful_comment_log_entry(
+            account_id,
+            channel_for_lookup,
+            reply_message_id,
+        )
+    except Exception:  # pragma: no cover - defensive logging
+        logging.exception("Не удалось проверить лог комментариев для ответа")
+        return False
 
 
 def _chat_allows_sending_message(message: Any) -> Tuple[bool, Optional[str]]:
@@ -671,7 +704,7 @@ async def _handle_linked_channel_message(
 
     current_last_reaction_at = last_reaction_at
 
-    if _is_reply_to_own_comment(message):
+    if await _is_reply_to_account_comment(message, account_id):
         reaction_comment_context = ' (ответ на комментарий аккаунта)'
         status_suffix = '_reply'
         updated_last_reaction_at, should_exit = await _maybe_send_reaction(

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -1377,6 +1377,107 @@ async def test_reaction_sent_for_reply_to_own_comment(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_reaction_for_reply_detected_via_comment_log(monkeypatch):
+    userid = 123
+    session = "+100500"
+    account_id = 42
+
+    original_active_sessions = dict(main.active_sessions)
+    original_quiet = set(main.quiet_sessions_notified)
+
+    main.active_sessions.clear()
+    main.quiet_sessions_notified.clear()
+    key = main.make_session_key(userid, session)
+    main.active_sessions[key] = True
+
+    client = DummyClient()
+
+    chat = types.SimpleNamespace(id=-2000000000, permissions=None, type="supergroup")
+    reply_message = types.SimpleNamespace(id=555, from_user=None)
+    from_user = types.SimpleNamespace(is_self=False)
+    message = types.SimpleNamespace(
+        chat=chat,
+        text="reply",
+        caption=None,
+        id=333,
+        reply_to_message=reply_message,
+        from_user=from_user,
+    )
+
+    comment_logs = []
+    updated_reactions: list[tuple[int, datetime]] = []
+
+    async def fake_add_comment_log(*args, **kwargs):
+        comment_logs.append((args, kwargs))
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    async def fake_count_reactions(*args, **kwargs):
+        return 0
+
+    async def fake_update_last_reaction_at(account, ts):
+        updated_reactions.append((account, ts))
+
+    async def fake_bot_send_message(*args, **kwargs):
+        return None
+
+    async def fake_has_successful_comment(account, channel, message_id):
+        assert account == account_id
+        assert channel == str(chat.id)
+        assert message_id == reply_message.id
+        return True
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
+    monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "count_reactions_for_message", fake_count_reactions)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
+    monkeypatch.setattr(main, "has_successful_comment_log_entry", fake_has_successful_comment)
+    monkeypatch.setattr(main.random, "uniform", lambda a, b: 0)
+    monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+
+    main.skip_log_counters.clear()
+    main.skip_log_last_reasons.clear()
+
+    try:
+        result = await main._handle_linked_channel_message(
+            client,
+            message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=0,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥"],
+            reaction_chance=0,
+            reaction_discussion_chance=0,
+            discussion_reply_prompt=None,
+            discussion_reply_chance=None,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=5,
+            reactions_enabled=True,
+            last_reaction_at=None,
+        )
+    finally:
+        main.active_sessions.clear()
+        main.active_sessions.update(original_active_sessions)
+        main.quiet_sessions_notified.clear()
+        main.quiet_sessions_notified.update(original_quiet)
+
+    assert client.sent_reactions == [(message.chat.id, message.id, "🔥")]
+    statuses = [kwargs.get("status") for _, kwargs in comment_logs]
+    assert "reaction_success_reply" in statuses
+    assert updated_reactions
+    assert updated_reactions[-1][0] == account_id
+    assert updated_reactions[-1][1] == result
+
+
+@pytest.mark.anyio
 async def test_reaction_happens_when_comment_skipped(monkeypatch):
     userid = 123
     session = "+100500"


### PR DESCRIPTION
## Summary
- add a database helper to detect successful comments by account
- treat discussion replies as account replies when a matching comment log is found
- cover the new branch with a unit test for reactions triggered from comment-log detection

## Testing
- pytest test_linked_discussion_handler.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e39465f57883308c2e8982092a7a12