### PR TITLE
Ensure reply reactions ignore cooldown

### DIFF
--- a/main.py
+++ b/main.py
@@ -301,6 +301,7 @@ async def _maybe_send_reaction(
     post_base_link: Optional[str],
     current_last_reaction_at: Optional[datetime],
     force: bool = False,
+    ignore_cooldown: bool = False,
 ) -> Tuple[Optional[datetime], bool]:
     if not reactions_enabled or not reaction_emojis:
         return current_last_reaction_at, False
@@ -432,7 +433,11 @@ async def _maybe_send_reaction(
             if previous is not None and previous.tzinfo is None:
                 previous = previous.replace(tzinfo=timezone.utc)
             cooldown_seconds = REACTION_MIN_INTERVAL_SECONDS
-            if previous is not None and cooldown_seconds:
+            if (
+                previous is not None
+                and cooldown_seconds
+                and not ignore_cooldown
+            ):
                 if now - previous < timedelta(seconds=cooldown_seconds):
                     reason = (
                         'reaction cooldown '
@@ -723,6 +728,7 @@ async def _handle_linked_channel_message(
             post_base_link=None,
             current_last_reaction_at=current_last_reaction_at,
             force=True,
+            ignore_cooldown=True,
         )
         current_last_reaction_at = updated_last_reaction_at
         return current_last_reaction_at

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -1328,7 +1328,7 @@ async def test_reaction_sent_for_reply_to_own_comment(monkeypatch):
     async def fake_bot_send_message(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 60)
     monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
     monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
     monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
@@ -1339,6 +1339,8 @@ async def test_reaction_sent_for_reply_to_own_comment(monkeypatch):
 
     main.skip_log_counters.clear()
     main.skip_log_last_reasons.clear()
+
+    recent_reaction = datetime.now(timezone.utc)
 
     try:
         result = await main._handle_linked_channel_message(
@@ -1360,7 +1362,7 @@ async def test_reaction_sent_for_reply_to_own_comment(monkeypatch):
             reaction_sleep_max=0,
             reaction_limit_per_message=5,
             reactions_enabled=True,
-            last_reaction_at=None,
+            last_reaction_at=recent_reaction,
         )
     finally:
         main.active_sessions.clear()
@@ -1374,6 +1376,7 @@ async def test_reaction_sent_for_reply_to_own_comment(monkeypatch):
     assert updated_reactions
     assert updated_reactions[-1][0] == account_id
     assert updated_reactions[-1][1] == result
+    assert result >= recent_reaction
 
 
 @pytest.mark.anyio
@@ -1428,7 +1431,7 @@ async def test_reaction_for_reply_detected_via_comment_log(monkeypatch):
         assert message_id == reply_message.id
         return True
 
-    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 60)
     monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
     monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
     monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
@@ -1440,6 +1443,8 @@ async def test_reaction_for_reply_detected_via_comment_log(monkeypatch):
 
     main.skip_log_counters.clear()
     main.skip_log_last_reasons.clear()
+
+    recent_reaction = datetime.now(timezone.utc)
 
     try:
         result = await main._handle_linked_channel_message(
@@ -1461,7 +1466,7 @@ async def test_reaction_for_reply_detected_via_comment_log(monkeypatch):
             reaction_sleep_max=0,
             reaction_limit_per_message=5,
             reactions_enabled=True,
-            last_reaction_at=None,
+            last_reaction_at=recent_reaction,
         )
     finally:
         main.active_sessions.clear()
@@ -1475,6 +1480,7 @@ async def test_reaction_for_reply_detected_via_comment_log(monkeypatch):
     assert updated_reactions
     assert updated_reactions[-1][0] == account_id
     assert updated_reactions[-1][1] == result
+    assert result >= recent_reaction
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- allow forced reactions to bypass the reaction cooldown by adding an `ignore_cooldown` flag
- always bypass the cooldown when reacting to replies to the account’s own comments
- extend linked discussion tests to cover reply reactions ignoring the cooldown

## Testing
- pytest test_linked_discussion_handler.py::test_reaction_sent_for_reply_to_own_comment -q
- pytest test_linked_discussion_handler.py::test_reaction_for_reply_detected_via_comment_log -q
- pytest test_linked_discussion_handler.py::test_reaction_skipped_when_cooldown_active -q


------
https://chatgpt.com/codex/tasks/task_e_68e3adba8530833094a7ea1927ab80e7