### PR TITLE
Allow forced reply reactions to ignore reaction limit

### DIFF
--- a/main.py
+++ b/main.py
@@ -324,7 +324,7 @@ async def _maybe_send_reaction(
     message_id = getattr(message, "id", None)
     limit = reaction_limit_per_message
 
-    if limit is not None:
+    if limit is not None and not force:
         if limit <= 0:
             reason = f'reaction limit {limit} reached'
             enqueue_skip_log(

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -1587,6 +1587,110 @@ async def test_reaction_sent_for_reply_to_own_comment(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_forced_reply_reaction_ignores_limit(monkeypatch):
+    userid = 321
+    session = "+300"
+    account_id = 77
+
+    original_active_sessions = dict(main.active_sessions)
+    original_quiet = set(main.quiet_sessions_notified)
+
+    main.active_sessions.clear()
+    main.quiet_sessions_notified.clear()
+    key = main.make_session_key(userid, session)
+    main.active_sessions[key] = True
+
+    client = DummyClient()
+
+    chat = types.SimpleNamespace(id=-5000000000, permissions=None, type="supergroup")
+    reply_author = types.SimpleNamespace(is_self=True)
+    reply_message = types.SimpleNamespace(from_user=reply_author)
+    from_user = types.SimpleNamespace(is_self=False)
+    message = types.SimpleNamespace(
+        chat=chat,
+        text="reply",
+        caption=None,
+        id=333,
+        reply_to_message=reply_message,
+        from_user=from_user,
+    )
+
+    comment_logs = []
+    skip_logs = []
+    updated_reactions: list[tuple[int, datetime]] = []
+
+    async def fake_add_comment_log(*args, **kwargs):
+        comment_logs.append((args, kwargs))
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    async def fake_count_reactions(*args, **kwargs):
+        return 0
+
+    async def fake_update_last_reaction_at(account, ts):
+        updated_reactions.append((account, ts))
+
+    async def fake_bot_send_message(*args, **kwargs):
+        return None
+
+    def fake_enqueue_skip_log(session_name, event_type, reason):
+        skip_logs.append((session_name, event_type, reason))
+
+    monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 60)
+    monkeypatch.setattr(main.bot, "send_message", fake_bot_send_message)
+    monkeypatch.setattr(main, "add_comment_log", fake_add_comment_log)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "count_reactions_for_message", fake_count_reactions)
+    monkeypatch.setattr(main, "update_last_reaction_at", fake_update_last_reaction_at)
+    monkeypatch.setattr(main.random, "uniform", lambda a, b: 0)
+    monkeypatch.setattr(main, "is_quiet_period", lambda: False)
+    monkeypatch.setattr(main, "enqueue_skip_log", fake_enqueue_skip_log)
+
+    main.skip_log_counters.clear()
+    main.skip_log_last_reasons.clear()
+
+    recent_reaction = datetime.now(timezone.utc)
+
+    try:
+        result = await main._handle_linked_channel_message(
+            client,
+            message,
+            userid=userid,
+            session=session,
+            account_id=account_id,
+            chance=0,
+            xsleep=0,
+            ysleep=0,
+            system_promt="prompt",
+            reaction_emojis=["🔥"],
+            reaction_chance=0,
+            reaction_discussion_chance=0,
+            discussion_reply_prompt=None,
+            discussion_reply_chance=None,
+            reaction_sleep_min=0,
+            reaction_sleep_max=0,
+            reaction_limit_per_message=0,
+            reactions_enabled=True,
+            last_reaction_at=recent_reaction,
+        )
+    finally:
+        main.active_sessions.clear()
+        main.active_sessions.update(original_active_sessions)
+        main.quiet_sessions_notified.clear()
+        main.quiet_sessions_notified.update(original_quiet)
+
+    assert client.sent_reactions == [(message.chat.id, message.id, "🔥")]
+    statuses = [kwargs.get("status") for _, kwargs in comment_logs]
+    assert "reaction_success_reply" in statuses
+    assert not skip_logs
+    assert updated_reactions
+    assert updated_reactions[-1][0] == account_id
+    assert updated_reactions[-1][1] == result
+    assert result >= recent_reaction
+
+
+@pytest.mark.anyio
 async def test_reaction_for_reply_detected_via_comment_log(monkeypatch):
     userid = 123
     session = "+100500"


### PR DESCRIPTION
## Summary
- skip reaction limit checks when a forced reaction should be sent (reply to own comment)
- add a regression test to ensure forced reply reactions are delivered even with zero limit

## Testing
- pytest test_linked_discussion_handler.py -k reply -q


------
https://chatgpt.com/codex/tasks/task_e_68e3f6d3f6b48330b2c06242c5798946