### PR TITLE
Handle replies to account comments in discussions

### DIFF
--- a/main.py
+++ b/main.py
@@ -204,8 +204,21 @@ def _is_discussion_reply_message(message: Any) -> bool:
     reply = getattr(message, "reply_to_message", None)
     if not reply:
         return False
+
     forward_chat = getattr(reply, "forward_from_chat", None)
-    return forward_chat is not None
+    if forward_chat is not None:
+        return True
+
+    chat = getattr(message, "chat", None)
+    chat_type = getattr(chat, "type", None)
+    if chat_type not in {"supergroup", "group"}:
+        return False
+
+    reply_author = getattr(reply, "from_user", None)
+    if reply_author and getattr(reply_author, "is_self", False):
+        return True
+
+    return False
 
 
 def _is_self_generated_message(message: Any) -> bool:

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -53,6 +53,30 @@ def clear_reaction_cache():
         main._chat_available_reactions_cache.update(original_cache)
 
 
+def test_discussion_reply_detection_for_account_comment():
+    chat = types.SimpleNamespace(type="supergroup")
+    reply_author = types.SimpleNamespace(is_self=True)
+    reply = types.SimpleNamespace(
+        forward_from_chat=None,
+        from_user=reply_author,
+    )
+    message = types.SimpleNamespace(chat=chat, reply_to_message=reply)
+
+    assert main._is_discussion_reply_message(message)
+
+
+def test_discussion_reply_detection_skips_private_chat():
+    chat = types.SimpleNamespace(type="private")
+    reply_author = types.SimpleNamespace(is_self=True)
+    reply = types.SimpleNamespace(
+        forward_from_chat=None,
+        from_user=reply_author,
+    )
+    message = types.SimpleNamespace(chat=chat, reply_to_message=reply)
+
+    assert not main._is_discussion_reply_message(message)
+
+
 @pytest.mark.anyio
 async def test_discussion_without_settings_skips_actions(monkeypatch):
     userid = 123


### PR DESCRIPTION
## Summary
- expand discussion reply detection to include replies to the account's own comments inside discussion chats
- add regression tests ensuring discussion replies are recognised only in group contexts

## Testing
- pytest test_linked_discussion_handler.py::test_discussion_reply_detection_for_account_comment test_linked_discussion_handler.py::test_discussion_reply_detection_skips_private_chat

------
https://chatgpt.com/codex/tasks/task_e_68e40379e72c8330a98e0c6b67576089