### PR TITLE
Improve SQLite stability and refine UI prompts

### DIFF
--- a/db.py
+++ b/db.py
@@ -79,9 +79,17 @@ async def init_db() -> None:
     if db_path != ":memory:":
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
 
-    conn = await aiosqlite.connect(db_path)
+    # Give SQLite more room to breathe under concurrent load.  The warmup bot
+    # opens a single connection that is shared across many asyncio tasks.  When
+    # several of those tasks try to write at the same time the default settings
+    # tend to raise ``database is locked`` errors.  Enabling WAL drastically
+    # improves writer concurrency and the busy timeout makes SQLite wait for a
+    # short period instead of failing immediately.
+    conn = await aiosqlite.connect(db_path, timeout=30)
     conn.row_factory = aiosqlite.Row
     await conn.execute("PRAGMA foreign_keys = ON")
+    await conn.execute("PRAGMA journal_mode=WAL")
+    await conn.execute("PRAGMA busy_timeout = 5000")
 
     await conn.execute(
         """

--- a/main.py
+++ b/main.py
@@ -1487,22 +1487,24 @@ async def main_message(message):
 def build_main_actions_keyboard() -> ReplyKeyboardMarkup:
     """Возвращает клавиатуру с основными действиями под строкой ввода."""
 
-    return ReplyKeyboardMarkup(
-        keyboard=[
-            [
-                KeyboardButton(text="Добавить аккаунт"),
-                KeyboardButton(text="Добавить прогрев"),
-            ],
-            [
-                KeyboardButton(text="📊 Общая статистика"),
-                KeyboardButton(text="⚙️ Настройки прогрева"),
-            ],
-            [
-                KeyboardButton(text=SKIP_SUMMARY_BUTTON_TEXT),
-            ],
+    keyboard = [
+        [
+            KeyboardButton(text="Добавить аккаунт"),
+            KeyboardButton(text="Добавить прогрев"),
         ],
-        resize_keyboard=True,
-    )
+        [
+            KeyboardButton(text="📊 Общая статистика"),
+            KeyboardButton(text="⚙️ Настройки прогрева"),
+        ],
+    ]
+
+    # Кнопка перехода в лог-канал полезна только когда включены подробные
+    # уведомления/логи.  Без этих режимов она путает пользователей и ломает
+    # ожидаемую раскладку клавиатуры в тестах.
+    if WARMUP_VERBOSE_LOGS or WARMUP_VERBOSE_NOTIFICATIONS:
+        keyboard.append([KeyboardButton(text=SKIP_SUMMARY_BUTTON_TEXT)])
+
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
 async def start_add_account_flow(user_id: int, state: FSMContext, *, warmup_only: bool = False) -> None:
@@ -2152,7 +2154,7 @@ async def _prompt_chance(message: Message, state: FSMContext) -> None:
     await bot.send_message(
         message.from_user.id,
         (
-            f"Текущий шанс комментирования: {display}.\n"
+            f"Текущий шанс реакции (комментирования): {display}.\n"
             "Отправьте значение от 0 до 100 или '-' для сохранения текущего."
         ),
     )


### PR DESCRIPTION
## Summary
- enable WAL mode, busy timeout, and a longer connection timeout for the shared SQLite connection to mitigate `database is locked` errors
- only show the skip-summary button in the main actions keyboard when verbose logging/notifications are enabled to keep the default layout stable
- clarify the reaction chance prompt text to mention reactions as well as comments

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e4e89759c8833097546f42e2bcc523