### PR TITLE
Stagger account launches and guard SQLite writes

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,18 +1,45 @@
 import os
 import json
 import asyncio
+import importlib
+import importlib.util
 import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, TYPE_CHECKING
 
 import aiosqlite
-import asyncpg
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    import asyncpg as asyncpg_type
+
+_asyncpg_spec = importlib.util.find_spec("asyncpg")
+
+if _asyncpg_spec is not None:
+    asyncpg = importlib.import_module("asyncpg")
+else:  # pragma: no cover - executed only when asyncpg is not installed
+    asyncpg = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    AsyncpgPool = asyncpg_type.pool.Pool  # pragma: no cover - typing only
+else:
+    AsyncpgPool = Any
+
+
+class _AsyncpgUniqueViolationError(Exception):
+    """Placeholder error used when asyncpg is unavailable."""
+
+
+if _asyncpg_spec is not None:
+    AsyncpgUniqueViolationError = asyncpg.UniqueViolationError  # type: ignore[attr-defined]
+else:  # pragma: no cover - executed only when asyncpg is not installed
+    AsyncpgUniqueViolationError = _AsyncpgUniqueViolationError
 
 
 _CONN: Optional[aiosqlite.Connection] = None
-_POOL: Optional[asyncpg.pool.Pool] = None
+_POOL: Optional[AsyncpgPool] = None
 _BACKEND: Optional[str] = None
+_SQLITE_LOCK: asyncio.Lock = asyncio.Lock()
 _UNSET = object()
 
 
@@ -66,7 +93,7 @@ def _serialize_list(value: Optional[Iterable[str]]) -> Optional[str]:
     return json.dumps(list(value))
 
 
-def _require_pool() -> asyncpg.pool.Pool:
+def _require_pool() -> AsyncpgPool:
     if not _is_postgres() or _POOL is None:
         raise DatabaseNotInitialized("PostgreSQL connection pool is not initialised. Call init_db() first.")
     return _POOL
@@ -122,7 +149,8 @@ async def _execute(query: str, params: Sequence[Any] = ()) -> None:
 
     if _is_sqlite():
         conn = await _require_conn()
-        await conn.execute(query, params_tuple)
+        async with _SQLITE_LOCK:
+            await conn.execute(query, params_tuple)
         return
 
     pool = _require_pool()
@@ -136,9 +164,10 @@ async def _execute_rowcount(query: str, params: Sequence[Any] = ()) -> int:
 
     if _is_sqlite():
         conn = await _require_conn()
-        cursor = await conn.execute(query, params_tuple)
-        rowcount = cursor.rowcount if cursor.rowcount is not None else 0
-        await cursor.close()
+        async with _SQLITE_LOCK:
+            cursor = await conn.execute(query, params_tuple)
+            rowcount = cursor.rowcount if cursor.rowcount is not None else 0
+            await cursor.close()
         return int(rowcount)
 
     pool = _require_pool()
@@ -156,8 +185,9 @@ async def _fetchone(query: str, params: Sequence[Any] = ()):
 
     if _is_sqlite():
         conn = await _require_conn()
-        async with conn.execute(query, params_tuple) as cursor:
-            return await cursor.fetchone()
+        async with _SQLITE_LOCK:
+            async with conn.execute(query, params_tuple) as cursor:
+                return await cursor.fetchone()
 
     pool = _require_pool()
     prepared_query, prepared_params = _prepare_query(query, params_tuple)
@@ -170,8 +200,9 @@ async def _fetchall(query: str, params: Sequence[Any] = ()):
 
     if _is_sqlite():
         conn = await _require_conn()
-        async with conn.execute(query, params_tuple) as cursor:
-            return await cursor.fetchall()
+        async with _SQLITE_LOCK:
+            async with conn.execute(query, params_tuple) as cursor:
+                return await cursor.fetchall()
 
     pool = _require_pool()
     prepared_query, prepared_params = _prepare_query(query, params_tuple)
@@ -182,7 +213,8 @@ async def _fetchall(query: str, params: Sequence[Any] = ()):
 async def _commit() -> None:
     if _is_sqlite():
         conn = await _require_conn()
-        await conn.commit()
+        async with _SQLITE_LOCK:
+            await conn.commit()
 
 
 async def init_db() -> None:
@@ -198,6 +230,10 @@ async def init_db() -> None:
         raise RuntimeError("DATABASE_URL environment variable is not set")
 
     if dsn.startswith(("postgres://", "postgresql://")):
+        if asyncpg is None:  # pragma: no cover - requires asyncpg installed
+            raise RuntimeError(
+                "asyncpg is required for PostgreSQL connections. Install the 'asyncpg' package to use a PostgreSQL DSN."
+            )
         _BACKEND = "postgres"
         _POOL = await asyncpg.create_pool(dsn)
         await _init_postgres_schema()
@@ -224,6 +260,9 @@ async def init_db() -> None:
     await conn.execute("PRAGMA foreign_keys = ON")
     await conn.execute("PRAGMA journal_mode=WAL")
     await conn.execute("PRAGMA busy_timeout = 5000")
+
+    await _init_sqlite_schema(conn)
+    _CONN = conn
 
 async def _init_sqlite_schema(conn: aiosqlite.Connection) -> None:
     await conn.execute(
@@ -802,8 +841,15 @@ async def update_account_settings(
         WHERE id = ?
     """
 
-    await _execute(query, tuple(values))
-    await _commit()
+    async def _perform_update() -> None:
+        await _execute(query, tuple(values))
+        await _commit()
+
+    if _is_sqlite():
+        await _retry_db_operation(_perform_update, max_retries=5)
+    else:
+        await _perform_update()
+
     print(f"DEBUG: SQL update completed successfully for account_id={account_id}")
 
 
@@ -869,8 +915,14 @@ async def bulk_update_reaction_settings(
         WHERE user_id = ?
     """
 
-    await _execute(query, tuple(values))
-    await _commit()
+    async def _perform_update() -> None:
+        await _execute(query, tuple(values))
+        await _commit()
+
+    if _is_sqlite():
+        await _retry_db_operation(_perform_update, max_retries=5)
+    else:
+        await _perform_update()
 
 
 async def update_last_reaction_at(account_id: int, timestamp: Optional[datetime]) -> None:
@@ -937,7 +989,7 @@ async def sync_warmup_channels(account_id: int, channels: List[str]) -> None:
         except sqlite3.IntegrityError as exc:  # pragma: no cover - defensive branch
             if "unique" not in str(exc).lower():
                 raise
-        except asyncpg.UniqueViolationError:  # pragma: no cover - PostgreSQL duplicate guard
+        except AsyncpgUniqueViolationError:  # pragma: no cover - PostgreSQL duplicate guard
             continue
 
     await _execute(

--- a/main.py
+++ b/main.py
@@ -1041,6 +1041,10 @@ async def _handle_linked_channel_message(
             reaction_comment_context = (
                 ' (без комментария)' if not comment_sent and comment_skipped else ''
             )
+            pause = COMMENT_TO_REACTION_PAUSE_SECONDS
+            if not comment_sent:
+                pause = max(pause / 2, 0.1)
+            await asyncio.sleep(pause)
             updated_last_reaction_at, should_exit = await _maybe_send_reaction(
                 client=client,
                 message=message,
@@ -1299,7 +1303,36 @@ async def ensure_latest_warmup_settings(force: bool = False) -> WarmupSettingsDa
 
 # Ограничение одновременных подключений
 MAX_CONCURRENT_ACCOUNTS = 5
+ACCOUNT_LAUNCH_STAGGER_SECONDS = 3
+ACCOUNT_LAUNCH_JITTER_SECONDS = 2
+COMMENT_TO_REACTION_PAUSE_SECONDS = 1.5
+
 account_semaphore = asyncio.Semaphore(MAX_CONCURRENT_ACCOUNTS)
+
+
+async def _delayed_safe_send_comments(
+    user_id: int,
+    session: str,
+    account_id: int,
+    delay: Optional[float] = None,
+) -> None:
+    pause = delay
+    if pause is None:
+        jitter = random.uniform(0, ACCOUNT_LAUNCH_JITTER_SECONDS)
+        pause = ACCOUNT_LAUNCH_STAGGER_SECONDS + jitter
+
+    await asyncio.sleep(max(pause, 0))
+    await safe_send_comments(user_id, session, account_id)
+
+
+def _schedule_safe_send_comments(
+    user_id: int,
+    session: str,
+    account_id: int,
+    *,
+    delay: Optional[float] = None,
+) -> None:
+    asyncio.create_task(_delayed_safe_send_comments(user_id, session, account_id, delay))
 
 
 def make_session_key(user_id: int, phone: str) -> str:
@@ -4187,7 +4220,7 @@ async def add_warmup_channels(message: Message, state: FSMContext) -> None:
             await send_account_summary_to_logs(account_id, session)
             
             await main_message(message)
-            asyncio.create_task(safe_send_comments(message.from_user.id, session, account_id))  # Запускаем комментирование
+            _schedule_safe_send_comments(message.from_user.id, session, account_id)
             return
         else:
             # Нет каналов в прогреве - запускаем в стандартном режиме
@@ -4211,7 +4244,7 @@ async def add_warmup_channels(message: Message, state: FSMContext) -> None:
             await send_account_summary_to_logs(account_id, session)
             
             await main_message(message)
-            asyncio.create_task(safe_send_comments(message.from_user.id, session, account_id))  # Запускаем комментирование
+            _schedule_safe_send_comments(message.from_user.id, session, account_id)
             return
 
     channels = [line.strip() for line in message.text.splitlines() if line.strip()]
@@ -4254,7 +4287,7 @@ async def add_warmup_channels(message: Message, state: FSMContext) -> None:
             await send_account_summary_to_logs(account_id, session)
             
             await main_message(message)
-            asyncio.create_task(safe_send_comments(message.from_user.id, session, account_id))  # Запускаем комментирование
+            _schedule_safe_send_comments(message.from_user.id, session, account_id)
             return
         else:
             # Нет каналов в прогреве - запускаем в стандартном режиме
@@ -4278,7 +4311,7 @@ async def add_warmup_channels(message: Message, state: FSMContext) -> None:
             await send_account_summary_to_logs(account_id, session)
             
             await main_message(message)
-            asyncio.create_task(safe_send_comments(message.from_user.id, session, account_id))  # Запускаем комментирование
+            _schedule_safe_send_comments(message.from_user.id, session, account_id)
             return
 
     try:
@@ -4315,7 +4348,7 @@ async def add_warmup_channels(message: Message, state: FSMContext) -> None:
     await send_account_summary_to_logs(account_id, session)
     
     await main_message(message)
-    asyncio.create_task(safe_send_comments(message.from_user.id, session, account_id))  # Запускаем комментирование
+    _schedule_safe_send_comments(message.from_user.id, session, account_id)
 
 
 async def safe_send_comments(user_id, phone, account_id):
@@ -4725,7 +4758,7 @@ async def main():
 
                     active_sessions[key] = True
                     active_account_ids[key] = account["id"]
-                    asyncio.create_task(safe_send_comments(user_id, phone, account["id"]))
+                    _schedule_safe_send_comments(user_id, phone, account["id"])
                     log_file.write(
                         f"Started account {phone} in {account.get('mode', 'unknown')} mode\n"
                     )


### PR DESCRIPTION
## Summary
- serialize SQLite operations with a shared asyncio lock so only one task writes to the SQLite database at a time
- schedule comment workers with a launch delay and pause between comments and reactions to spread account activity in time

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e505b60de883309a8ecb4d260f27fb