### PR TITLE
Follow-up: ensure session persistence failures don't leave clients running

### DIFF
--- a/main.py
+++ b/main.py
@@ -1717,6 +1717,13 @@ async def check_account(user_id, phone):
             if started:
                 try:
                     await _persist_session_string(user_id, phone, client)
+                except Exception:
+                    logging.exception(
+                        "Не удалось сохранить строку сессии после проверки аккаунта %s",
+                        phone,
+                    )
+
+                try:
                     await _stop_client_with_retries(
                         client,
                         session_file=None if uses_in_memory else session_path,

--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -233,6 +233,16 @@ async def migrate(sqlite_path: str, postgres_dsn: str) -> None:
                     """,
                 )
 
+                for sequence_name, table_name in (
+                    ("accounts_id_seq", "accounts"),
+                    ("warmup_channels_id_seq", "warmup_channels"),
+                    ("comment_logs_id_seq", "comment_logs"),
+                ):
+                    next_value = await pg.fetchval(
+                        f"SELECT COALESCE(MAX(id), 0) + 1 FROM {table_name}"
+                    )
+                    await pg.execute("SELECT setval($1, $2, false)", sequence_name, next_value)
+
     sqlite_conn.close()
 
 


### PR DESCRIPTION
## Summary
- replace the SQLite-only database layer with a backend-agnostic implementation that supports asyncpg and synchronises session data through the new telegram_sessions table
- rework Pyrogram client handling to persist session strings in PostgreSQL while keeping file-based fallbacks for legacy environments and tests
- add PostgreSQL infrastructure (docker-compose service, init.sql), a data migration script, dependency updates, and refresh the migration documentation
- ensure the check_account cleanup always stops the Pyrogram client even if persisting the session string raises an error
- advance PostgreSQL sequences after bulk-importing data so future inserts do not reuse existing IDs

## Testing
- pytest test_check_account.py -k check_account *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_68e572c79ac4833087b48458b5db9f8d