### PR TITLE
Ensure check_account cleanup stops client and reset migrated sequences

### DIFF
--- a/main.py
+++ b/main.py
@@ -1722,23 +1722,23 @@ async def check_account(user_id, phone):
                         "Не удалось сохранить строку сессии после проверки аккаунта %s",
                         phone,
                     )
-
-                try:
-                    await _stop_client_with_retries(
-                        client,
-                        session_file=None if uses_in_memory else session_path,
-                        attempts=4,
-                    )
-                except sqlite3.OperationalError:
-                    logging.exception(
-                        "Не удалось остановить клиент проверки аккаунта %s из-за блокировки БД",
-                        getattr(client, "name", "<unknown>"),
-                    )
-                except Exception:
-                    logging.exception(
-                        "Не удалось остановить клиент проверки аккаунта %s",
-                        getattr(client, "name", "<unknown>"),
-                    )
+                finally:
+                    try:
+                        await _stop_client_with_retries(
+                            client,
+                            session_file=None if uses_in_memory else session_path,
+                            attempts=4,
+                        )
+                    except sqlite3.OperationalError:
+                        logging.exception(
+                            "Не удалось остановить клиент проверки аккаунта %s из-за блокировки БД",
+                            getattr(client, "name", "<unknown>"),
+                        )
+                    except Exception:
+                        logging.exception(
+                            "Не удалось остановить клиент проверки аккаунта %s",
+                            getattr(client, "name", "<unknown>"),
+                        )
 
 async def main_message(message):
     user_id = message.from_user.id

--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -238,10 +238,10 @@ async def migrate(sqlite_path: str, postgres_dsn: str) -> None:
                     ("warmup_channels_id_seq", "warmup_channels"),
                     ("comment_logs_id_seq", "comment_logs"),
                 ):
-                    next_value = await pg.fetchval(
-                        f"SELECT COALESCE(MAX(id), 0) + 1 FROM {table_name}"
+                    await pg.execute(
+                        f"SELECT setval($1, COALESCE((SELECT MAX(id) FROM {table_name}), 0) + 1, false)",
+                        sequence_name,
                     )
-                    await pg.execute("SELECT setval($1, $2, false)", sequence_name, next_value)
 
     sqlite_conn.close()
 


### PR DESCRIPTION
## Summary
- ensure the check_account cleanup always stops the Pyrogram client even if session persistence fails
- advance PostgreSQL sequences during the SQLite-to-Postgres migration after copying explicit ids

## Testing
- pytest test_check_account.py *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_68e576dc44c48330b41d2494a91170c0