### PR TITLE
Fix docker-compose volume name syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,14 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5433:5432"
+      - "${POSTGRES_PORT:-5433}:5432"
     restart: unless-stopped
 
   bot:
     build: .
     container_name: ${PROJECT_NAME:-telegrambot}_bot
     environment:
-      - DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER:-bot_user}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-telegram_bot}
+      - DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER:-bot_user}:${POSTGRES_PASSWORD}@${PROJECT_NAME:-telegrambot}_postgres:5432/${POSTGRES_DB:-telegram_bot}
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
## Summary
- use a fixed name for the postgres volume while keeping container names dynamic
- expose the postgres port via an overridable environment variable
- update the bot service connection string to match the renamed postgres container

## Testing
- docker-compose config

------
https://chatgpt.com/codex/tasks/task_e_68e6a53ac1c48330b38fe0810c4d5f54