### PR TITLE
Fix docker compose volume naming

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - ${PROJECT_NAME}_postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     restart: unless-stopped
@@ -34,7 +34,7 @@ services:
       - project
 
 volumes:
-  ${PROJECT_NAME}_postgres_data:
+  postgres_data:
 
 networks:
   project:


### PR DESCRIPTION
## Summary
- replace the postgres service volume mapping to use a fixed `postgres_data` name
- declare the `postgres_data` volume without environment variable interpolation to satisfy docker compose validation

## Testing
- docker compose config *(fails: `docker` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6a5f4dcdc8330bae2e2b01ca4092f