### PR TITLE
Ensure cancellation path respects disconnect timeout

### DIFF
--- a/main.py
+++ b/main.py
@@ -331,7 +331,26 @@ async def safe_session_operation(
                         op_name,
                     )
                     try:
-                        await close_task
+                        if disconnect_timeout is not None:
+                            elapsed = loop.time() - disconnect_started_at
+                            remaining_timeout = disconnect_timeout - elapsed
+                            if remaining_timeout <= 0:
+                                raise asyncio.TimeoutError
+                            await asyncio.wait_for(
+                                asyncio.shield(close_task),
+                                timeout=remaining_timeout,
+                            )
+                        else:
+                            await asyncio.shield(close_task)
+                    except asyncio.TimeoutError:
+                        close_task.cancel()
+                        with suppress(Exception):
+                            await close_task
+                        logging.error(
+                            "safe_session_operation[%s]: timeout while closing client after %.2fs",
+                            op_name,
+                            loop.time() - disconnect_started_at,
+                        )
                     except Exception:
                         logging.exception(
                             "safe_session_operation[%s]: error while waiting for client close during cancellation",


### PR DESCRIPTION
## Summary
- ensure the cancellation branch of `safe_session_operation` enforces the remaining disconnect timeout while waiting for the client to close
- cancel and await the client close task with proper logging when the timeout elapses during cancellation

## Testing
- pytest test_check_account.py

------
https://chatgpt.com/codex/tasks/task_e_68e77b322c2483308c9081af7db98428