### PR TITLE
Fix incorrect startaccount system prompt state usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -2440,7 +2440,7 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
 
                 await callback_query.answer()
                 await _prompt_system_prompt(callback_query, state)
-                await state.set_state(startaccount.systempromt)
+                await state.set_state(startaccount.system_prompt)
             except Exception as exc:
                 logging.exception("Failed to start account %s for user %s: %s", session, user_id, exc)
                 await bot.send_message(user_id, f"Ошибка: {str(exc)}")


### PR DESCRIPTION
## Summary
- correct the startaccount system state assignment to use the defined system_prompt state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7859a7e588330bb24f04e20758410