### PR TITLE
Add reaction logging tables and safe reaction handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,48 @@ docker-compose logs -f         # Просмотр логов
 - Скрипт `fix_mode.py` можно запускать вручную для принудительного выхода аккаунтов из прогрева.
 - Для очистки устаревших записей комментариев используется автоматическая задача (по умолчанию каждые 6 часов).
 
+### Настройка реакций
+
+- Таблицы `posts` и `reaction_logs` создаются автоматически при первом подключении к базе данных. Они используются для отслеживания обработанных постов и состояний реакций (успех, пропуск, ошибка).
+- Перед выдачей реакций убедитесь, что аккаунт находится в статусе `running` и включает реакции:
+  ```sql
+  UPDATE accounts
+  SET status = 'running', reactions_enabled = TRUE
+  WHERE id = 1;
+  ```
+- Основные параметры хранятся в таблице `accounts` и могут настраиваться напрямую:
+  ```sql
+  UPDATE accounts SET
+      reaction_chance = 70,
+      reaction_discussion_chance = 80,
+      discussion_reply_chance = 50,
+      discussion_reply_prompt = 'Ты молодец',
+      reaction_sleep_min = 30,
+      reaction_sleep_max = 90,
+      reaction_emojis = '["❤️", "👍"]',
+      reaction_limit_per_message = 8,
+      reactions_enabled = TRUE
+  WHERE id = 1;
+  ```
+- Настройки из интерфейса бота автоматически синхронизируются с колонками `accounts`. При необходимости можно использовать метод `bulk_update_reaction_settings` для массового применения.
+
+### Мониторинг реакций
+
+- Все попытки реакций логируются в таблицу `reaction_logs`. Поле `status` принимает значения `success`, `skipped` или `failed`, а `error_message` содержит пояснения.
+- Для оперативного контроля можно использовать SQL-запросы:
+  ```sql
+  SELECT status, COUNT(*)
+  FROM reaction_logs
+  WHERE account_id = 1
+  GROUP BY status;
+  ```
+- Аналитика по реакциям также попадает в `comment_logs`, поэтому существующие отчёты остаются совместимыми.
+- Живые логи удобно просматривать через Docker или journalctl:
+  ```bash
+  docker logs bot_container | grep -i "reaction"
+  docker logs bot_container | grep -i "error"
+  ```
+
 ## Тестирование
 
 Перед развёртыванием рекомендуется выполнить тесты:

--- a/add_missing_tables.sql
+++ b/add_missing_tables.sql
@@ -18,6 +18,34 @@ CREATE TABLE IF NOT EXISTS comment_logs (
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Posts table
+CREATE TABLE IF NOT EXISTS posts (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    post_id BIGINT NOT NULL,
+    message TEXT,
+    has_media BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(account_id, channel, post_id)
+);
+
+-- Reaction logs table
+CREATE TABLE IF NOT EXISTS reaction_logs (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    message_id BIGINT NOT NULL,
+    emoji TEXT NOT NULL,
+    status TEXT NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_posts_account_id ON posts(account_id);
+CREATE INDEX IF NOT EXISTS idx_reaction_logs_account_id ON reaction_logs(account_id);
+CREATE INDEX IF NOT EXISTS idx_reaction_logs_channel_message ON reaction_logs(channel, message_id);
+
 -- Warmup settings table
 CREATE TABLE IF NOT EXISTS warmup_settings (
     id BIGSERIAL PRIMARY KEY,

--- a/create_all_tables.sql
+++ b/create_all_tables.sql
@@ -56,6 +56,34 @@ CREATE TABLE IF NOT EXISTS comment_logs (
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Posts table for tracking processed posts
+CREATE TABLE IF NOT EXISTS posts (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    post_id BIGINT NOT NULL,
+    message TEXT,
+    has_media BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(account_id, channel, post_id)
+);
+
+-- Reaction logs table
+CREATE TABLE IF NOT EXISTS reaction_logs (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    message_id BIGINT NOT NULL,
+    emoji TEXT NOT NULL,
+    status TEXT NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_posts_account_id ON posts(account_id);
+CREATE INDEX IF NOT EXISTS idx_reaction_logs_account_id ON reaction_logs(account_id);
+CREATE INDEX IF NOT EXISTS idx_reaction_logs_channel_message ON reaction_logs(channel, message_id);
+
 -- Warmup settings table
 CREATE TABLE IF NOT EXISTS warmup_settings (
     id BIGSERIAL PRIMARY KEY,

--- a/db.py
+++ b/db.py
@@ -3,7 +3,7 @@ import json
 import importlib
 import importlib.util
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
@@ -339,6 +339,36 @@ async def _init_postgres_schema() -> None:
 
         await connection.execute(
             """
+            CREATE TABLE IF NOT EXISTS posts (
+                id BIGSERIAL PRIMARY KEY,
+                account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                channel TEXT NOT NULL,
+                post_id BIGINT NOT NULL,
+                message TEXT,
+                has_media BOOLEAN DEFAULT FALSE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(account_id, channel, post_id)
+            )
+            """
+        )
+
+        await connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reaction_logs (
+                id BIGSERIAL PRIMARY KEY,
+                account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                channel TEXT NOT NULL,
+                message_id BIGINT NOT NULL,
+                emoji TEXT NOT NULL,
+                status TEXT NOT NULL,
+                error_message TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+        await connection.execute(
+            """
             CREATE TABLE IF NOT EXISTS telegram_sessions (
                 id BIGSERIAL PRIMARY KEY,
                 user_id BIGINT NOT NULL,
@@ -369,6 +399,27 @@ async def _init_postgres_schema() -> None:
             """
             CREATE INDEX IF NOT EXISTS idx_telegram_sessions_user_phone
             ON telegram_sessions (user_id, phone)
+            """
+        )
+
+        await connection.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_posts_account_id
+            ON posts (account_id)
+            """
+        )
+
+        await connection.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reaction_logs_account_id
+            ON reaction_logs (account_id)
+            """
+        )
+
+        await connection.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reaction_logs_channel_message
+            ON reaction_logs (channel, message_id)
             """
         )
 
@@ -772,7 +823,9 @@ async def bulk_update_reaction_settings(
 
 
 async def update_last_reaction_at(account_id: int, timestamp: Optional[datetime]) -> None:
-    value = timestamp.isoformat() if timestamp is not None else None
+    value = timestamp
+    if value is not None and value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
     await _execute(
         """
         UPDATE accounts
@@ -1046,8 +1099,72 @@ async def add_comment_log(
     )
 
 
+async def record_post(
+    account_id: int,
+    *,
+    channel: str,
+    post_id: int,
+    message: Optional[str],
+    has_media: bool,
+) -> None:
+    await _execute(
+        """
+        INSERT INTO posts (account_id, channel, post_id, message, has_media)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT (account_id, channel, post_id) DO UPDATE SET
+            message = EXCLUDED.message,
+            has_media = EXCLUDED.has_media,
+            created_at = CURRENT_TIMESTAMP
+        """,
+        (
+            account_id,
+            channel,
+            post_id,
+            message,
+            adapt_bool(has_media),
+        ),
+    )
+
+
+async def add_reaction_log(
+    account_id: int,
+    *,
+    channel: str,
+    message_id: int,
+    emoji: Optional[str],
+    status: str,
+    error_message: Optional[str] = None,
+) -> None:
+    emoji_value = emoji if emoji else "N/A"
+    await _execute(
+        """
+        INSERT INTO reaction_logs (account_id, channel, message_id, emoji, status, error_message)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            account_id,
+            channel,
+            message_id,
+            emoji_value,
+            status,
+            error_message,
+        ),
+    )
+
+
 async def count_reactions_for_message(channel: str, message_id: int) -> int:
     row = await _fetchone(
+        """
+        SELECT COUNT(*) AS reaction_count
+        FROM reaction_logs
+        WHERE status = 'success' AND channel = ? AND message_id = ?
+        """,
+        (channel, message_id),
+    )
+    if row and row["reaction_count"] is not None:
+        return int(row["reaction_count"])
+
+    fallback_row = await _fetchone(
         """
         SELECT COUNT(*) AS reaction_count
         FROM comment_logs
@@ -1055,9 +1172,9 @@ async def count_reactions_for_message(channel: str, message_id: int) -> int:
         """,
         (channel, message_id),
     )
-    if not row:
+    if not fallback_row:
         return 0
-    return int(row["reaction_count"] or 0)
+    return int(fallback_row["reaction_count"] or 0)
 
 
 async def has_successful_comment_log_entry(

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 from comment_engine import generate_comment
 from db import (
     add_comment_log,
+    add_reaction_log,
     bulk_update_reaction_settings,
     count_reactions_for_message,
     db_update_warmup_schedule,
@@ -56,6 +57,7 @@ from db import (
     mark_account_stopped,
     mark_warmup_channel_joined,
     record_warmup_channel_error,
+    record_post,
     reset_warmup_daily_state,
     set_account_mode,
     set_user_authenticated,
@@ -850,7 +852,31 @@ async def _maybe_send_reaction(
     chat_obj = getattr(message, "chat", None)
     chat_id_for_reactions = getattr(chat_obj, "id", None)
     channel_for_reactions = str(chat_id_for_reactions or "")
-    message_id = getattr(message, "id", None)
+    if not channel_for_reactions:
+        channel_for_reactions = "unknown"
+    message_id_raw = getattr(message, "id", None)
+    try:
+        message_id_int = int(message_id_raw)
+    except (TypeError, ValueError):
+        message_id_int = None
+    message_id = message_id_int
+
+    async def log_reaction_event(
+        status: str,
+        *,
+        emoji: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        if message_id_int is None:
+            return
+        await add_reaction_log(
+            account_id,
+            channel=channel_for_reactions,
+            message_id=message_id_int,
+            emoji=emoji,
+            status=status,
+            error_message=error,
+        )
 
     cleaned_reaction_emojis: List[str] = []
     for emoji in reaction_emojis:
@@ -962,6 +988,7 @@ async def _maybe_send_reaction(
                 status=f'reaction_skipped{status_suffix}',
                 error=reason,
             )
+            await log_reaction_event("skipped", error=reason)
             return current_last_reaction_at, True
         if channel_for_reactions and message_id is not None:
             reaction_count = await count_reactions_for_message(channel_for_reactions, message_id)
@@ -980,6 +1007,7 @@ async def _maybe_send_reaction(
                     status=f'reaction_skipped{status_suffix}',
                     error=reason,
                 )
+                await log_reaction_event("skipped", error=reason)
                 return current_last_reaction_at, True
 
     reaction_roll = 0
@@ -1021,6 +1049,7 @@ async def _maybe_send_reaction(
                 status=f'reaction_skipped{status_suffix}',
                 error=reason,
             )
+            await log_reaction_event("skipped", error=reason)
             return current_last_reaction_at, False
     else:
         logger.info(
@@ -1077,11 +1106,12 @@ async def _maybe_send_reaction(
         await asyncio.sleep(0.2)
         await add_comment_log(
             account_id,
-            channel=str(getattr(getattr(message, "chat", None), "id", "")),
-            message_id=message.id,
+            channel=channel_for_reactions,
+            message_id=message_id,
             status=f'reaction_skipped{status_suffix}',
             error=reason,
         )
+        await log_reaction_event("skipped", error=reason)
         return current_last_reaction_at, True
 
     max_reaction_attempts = 3
@@ -1123,14 +1153,85 @@ async def _maybe_send_reaction(
                     await asyncio.sleep(0.2)
                     await add_comment_log(
                         account_id,
-                        channel=str(message.chat.id),
-                        message_id=message.id,
+                        channel=channel_for_reactions,
+                        message_id=message_id,
                         status=f'reaction_skipped{status_suffix}',
                         error=reason,
                     )
+                    await log_reaction_event("skipped", error=reason)
                     return current_last_reaction_at, True
 
-            await client.send_reaction(message.chat.id, message.id, reaction_emoji)
+            message_identifier = message_id
+            if message_identifier is None:
+                message_identifier = message_id_raw
+            try:
+                message_identifier_int = int(message_identifier)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                message_identifier_int = getattr(message, "id", 0)
+
+            sent, error_text = await send_reaction_safe(
+                client,
+                message.chat.id,
+                int(message_identifier_int),
+                reaction_emoji,
+            )
+            if not sent:
+                refreshed_allowed = await _get_chat_available_quick_reactions(
+                    client,
+                    chat_id_for_reactions,
+                    force_refresh=True,
+                )
+                if refreshed_allowed is not None:
+                    allowed_reaction_emojis = refreshed_allowed
+                invalid_emojis: Set[str] = {reaction_emoji}
+                if refreshed_allowed is not None:
+                    invalid_emojis.update(
+                        {
+                            emoji
+                            for emoji in working_reaction_emojis
+                            if emoji not in refreshed_allowed
+                        }
+                    )
+                    working_reaction_emojis = [
+                        emoji
+                        for emoji in working_reaction_emojis
+                        if emoji in refreshed_allowed
+                    ]
+                else:
+                    invalid_emojis.update(working_reaction_emojis)
+                    working_reaction_emojis = []
+
+                invalid_text = " ".join(sorted(invalid_emojis)) if invalid_emojis else reaction_emoji
+                reason = (
+                    f"reaction invalid for emoji {reaction_emoji}: "
+                    f"unsupported emojis {invalid_text}"
+                )
+                last_reaction_error_text = error_text or reason
+                logging.warning(
+                    "Reaction invalid for chat %s with emojis %s: %s",
+                    chat_id_for_reactions,
+                    invalid_text,
+                    error_text,
+                )
+                if working_reaction_emojis:
+                    continue
+
+                enqueue_skip_log(
+                    session,
+                    "reaction",
+                    f"{reason}{reaction_comment_context}",
+                )
+                await asyncio.sleep(0.2)
+                await add_comment_log(
+                    account_id,
+                    channel=channel_for_reactions,
+                    message_id=message_id,
+                    status=f'reaction_skipped{status_suffix}',
+                    error=reason,
+                )
+                await log_reaction_event("skipped", emoji=reaction_emoji, error=reason)
+                return current_last_reaction_at, True
+
             reaction_link = post_base_link or _build_post_link(message, message)
             if (
                 reaction_link
@@ -1151,68 +1252,13 @@ async def _maybe_send_reaction(
             await asyncio.sleep(0.2)
             await add_comment_log(
                 account_id,
-                channel=str(getattr(getattr(message, "chat", None), "id", "")),
-                message_id=message.id,
+                channel=channel_for_reactions,
+                message_id=message_id,
                 status=f'reaction_success{status_suffix}',
             )
+            await log_reaction_event("success", emoji=reaction_emoji)
             reaction_sent = True
             break
-        except ReactionInvalid as reaction_error:
-            last_reaction_error = reaction_error
-            refreshed_allowed = await _get_chat_available_quick_reactions(
-                client,
-                chat_id_for_reactions,
-                force_refresh=True,
-            )
-            if refreshed_allowed is not None:
-                allowed_reaction_emojis = refreshed_allowed
-            invalid_emojis: Set[str] = {reaction_emoji}
-            if refreshed_allowed is not None:
-                invalid_emojis.update(
-                    {
-                        emoji
-                        for emoji in working_reaction_emojis
-                        if emoji not in refreshed_allowed
-                    }
-                )
-                working_reaction_emojis = [
-                    emoji
-                    for emoji in working_reaction_emojis
-                    if emoji in refreshed_allowed
-                ]
-            else:
-                invalid_emojis.update(working_reaction_emojis)
-                working_reaction_emojis = []
-
-            invalid_text = " ".join(sorted(invalid_emojis)) if invalid_emojis else str(reaction_emoji)
-            reason = (
-                f"reaction invalid for emoji {reaction_emoji}: "
-                f"unsupported emojis {invalid_text}"
-            )
-            last_reaction_error_text = reason
-            logging.warning(
-                "Reaction invalid for chat %s with emojis %s: %s",
-                chat_id_for_reactions,
-                invalid_text,
-                reaction_error,
-            )
-            if working_reaction_emojis:
-                continue
-
-            enqueue_skip_log(
-                session,
-                "reaction",
-                f"{reason}{reaction_comment_context}",
-            )
-            await asyncio.sleep(0.2)
-            await add_comment_log(
-                account_id,
-                channel=str(getattr(getattr(message, "chat", None), "id", "")),
-                message_id=message.id,
-                status=f'reaction_skipped{status_suffix}',
-                error=reason,
-            )
-            return current_last_reaction_at, True
         except Exception as reaction_error:
             last_reaction_error = reaction_error
             last_reaction_error_text = str(reaction_error)
@@ -1240,11 +1286,12 @@ async def _maybe_send_reaction(
         await asyncio.sleep(0.2)
         await add_comment_log(
             account_id,
-            channel=str(message.chat.id),
-            message_id=message.id,
+            channel=channel_for_reactions,
+            message_id=message_id,
             status=f'reaction_error{status_suffix}',
             error=error_text,
         )
+        await log_reaction_event("failed", error=error_text)
 
     return current_last_reaction_at, False
 
@@ -1253,6 +1300,40 @@ def _extract_post_text(message: Any) -> Optional[str]:
     text = getattr(message, "text", None)
     caption = getattr(message, "caption", None)
     return text if text is not None else caption
+
+
+def _message_has_media(message: Any) -> bool:
+    media_attributes = (
+        "photo",
+        "video",
+        "animation",
+        "document",
+        "audio",
+        "voice",
+        "video_note",
+        "sticker",
+    )
+
+    for attr in media_attributes:
+        if getattr(message, attr, None) is not None:
+            return True
+
+    media = getattr(message, "media", None)
+    return bool(media)
+
+
+async def send_reaction_safe(client: Client, chat_id: int, message_id: int, emoji: str) -> Tuple[bool, Optional[str]]:
+    try:
+        await client.send_reaction(chat_id, message_id, emoji)
+        return True, None
+    except ReactionInvalid as exc:
+        logging.warning("Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
+        return False, str(exc)
+    except Exception as exc:
+        if "REACTION_INVALID" in str(exc).upper():
+            logging.warning("Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
+            return False, str(exc)
+        raise
 
 
 def _build_post_link(sent_message: Any, original_message: Any) -> str:
@@ -1434,6 +1515,25 @@ async def _handle_linked_channel_message(
             error='no text or caption',
         )
         return current_last_reaction_at
+
+    channel_identifier = str(getattr(getattr(message, "chat", None), "id", ""))
+    raw_message_id = getattr(message, "id", None)
+    try:
+        numeric_message_id = int(raw_message_id)
+    except (TypeError, ValueError):
+        numeric_message_id = None
+
+    if channel_identifier and numeric_message_id is not None:
+        try:
+            await record_post(
+                account_id,
+                channel=channel_identifier,
+                post_id=numeric_message_id,
+                message=post_text,
+                has_media=_message_has_media(message),
+            )
+        except Exception:
+            logging.exception("Не удалось сохранить информацию о посте для реакций")
 
     can_send, reason = _chat_allows_sending_message(message)
     if not can_send:

--- a/test_reaction_logging_unit.py
+++ b/test_reaction_logging_unit.py
@@ -1,0 +1,146 @@
+import os
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("API_ID", "123")
+os.environ.setdefault("API_HASH", "hash")
+os.environ.setdefault("BOT_TOKEN", "123456:TEST")
+
+import db
+from main import send_reaction_safe
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_record_post_upsert(monkeypatch):
+    captured = {}
+
+    async def fake_execute(query, params=()):
+        captured["query"] = query
+        captured["params"] = params
+
+    monkeypatch.setattr(db, "_execute", fake_execute)
+
+    await db.record_post(
+        1,
+        channel="test_channel",
+        post_id=42,
+        message="hello",
+        has_media=True,
+    )
+
+    assert "ON CONFLICT (account_id, channel, post_id)" in captured["query"]
+    assert captured["params"] == (1, "test_channel", 42, "hello", True)
+
+
+@pytest.mark.anyio
+async def test_add_reaction_log_sets_placeholder(monkeypatch):
+    calls = {}
+
+    async def fake_execute(query, params=()):
+        calls["params"] = params
+
+    monkeypatch.setattr(db, "_execute", fake_execute)
+
+    await db.add_reaction_log(
+        7,
+        channel="chan",
+        message_id=55,
+        emoji=None,
+        status="skipped",
+        error_message="limit",
+    )
+
+    assert calls["params"] == (7, "chan", 55, "N/A", "skipped", "limit")
+
+
+@pytest.mark.anyio
+async def test_update_last_reaction_at_normalises_timezone(monkeypatch):
+    calls = []
+
+    async def fake_execute(query, params=()):
+        calls.append(params)
+
+    monkeypatch.setattr(db, "_execute", fake_execute)
+
+    naive_time = datetime(2024, 1, 1, 12, 0, 0)
+    await db.update_last_reaction_at(3, naive_time)
+
+    assert calls[0][0].tzinfo is not None
+    assert calls[0][1] == 3
+
+
+@pytest.mark.anyio
+async def test_count_reactions_for_message_prefers_reaction_logs(monkeypatch):
+    queries = []
+
+    async def fake_fetchone(query, params=()):
+        queries.append((query.strip(), params))
+        if "FROM reaction_logs" in query:
+            return {"reaction_count": 5}
+        return {"reaction_count": 2}
+
+    monkeypatch.setattr(db, "_fetchone", fake_fetchone)
+
+    count = await db.count_reactions_for_message("chan", 77)
+
+    assert count == 5
+    assert any("FROM reaction_logs" in q[0] for q in queries)
+    assert len(queries) == 1
+
+
+@pytest.mark.anyio
+async def test_count_reactions_for_message_falls_back(monkeypatch):
+    calls = []
+
+    async def fake_fetchone(query, params=()):
+        calls.append(query.strip())
+        if len(calls) == 1:
+            return {"reaction_count": None}
+        return {"reaction_count": 4}
+
+    monkeypatch.setattr(db, "_fetchone", fake_fetchone)
+
+    count = await db.count_reactions_for_message("chan", 10)
+
+    assert count == 4
+    assert len(calls) == 2
+
+
+@pytest.mark.anyio
+async def test_send_reaction_safe_handles_invalid():
+    events = SimpleNamespace(sent=False)
+
+    class DummyClient:
+        async def send_reaction(self, chat_id, message_id, emoji):
+            events.sent = True
+            raise RuntimeError("RPC_CALL_FAIL: REACTION_INVALID")
+
+    dummy = DummyClient()
+
+    sent, error = await send_reaction_safe(dummy, 1, 2, "🔥")
+    assert not sent
+    assert "REACTION_INVALID" in (error or "")
+    assert events.sent
+
+
+@pytest.mark.anyio
+async def test_send_reaction_safe_success():
+    events = SimpleNamespace(sent=False)
+
+    class DummyClient:
+        async def send_reaction(self, chat_id, message_id, emoji):
+            events.sent = True
+
+    dummy = DummyClient()
+
+    sent, error = await send_reaction_safe(dummy, 1, 2, "👍")
+    assert sent
+    assert error is None
+    assert events.sent


### PR DESCRIPTION
## Summary
- create `posts` and `reaction_logs` tables plus supporting indexes in the Postgres initialisation scripts
- add helpers to persist processed posts, normalise reaction tracking, and harden reaction sending with logging hooks
- document reaction configuration/monitoring steps and add unit tests for the reaction logging utilities

## Testing
- pytest test_reaction_logging_unit.py


------
https://chatgpt.com/codex/tasks/task_e_68e7a2f3299c83309d66a7fe7ab78b44