### PR TITLE
Fix reaction count fallback to legacy logs

### DIFF
--- a/db.py
+++ b/db.py
@@ -1161,8 +1161,10 @@ async def count_reactions_for_message(channel: str, message_id: int) -> int:
         """,
         (channel, message_id),
     )
-    if row and row["reaction_count"] is not None:
-        return int(row["reaction_count"])
+    if row:
+        reaction_count = int(row["reaction_count"] or 0)
+        if reaction_count > 0:
+            return reaction_count
 
     fallback_row = await _fetchone(
         """


### PR DESCRIPTION
## Summary
- ensure `count_reactions_for_message` only returns the new reaction log count when it is non-zero so legacy comment log counts are still used as a fallback

## Testing
- pytest test_reaction_logging_unit.py

------
https://chatgpt.com/codex/tasks/task_e_68e7ab310ed8833086d44aae53dd013f