### PR TITLE
Improve reaction handling and bootstrap database

### DIFF
--- a/db.py
+++ b/db.py
@@ -822,10 +822,29 @@ async def bulk_update_reaction_settings(
     await _execute(query, tuple(values))
 
 
-async def update_last_reaction_at(account_id: int, timestamp: Optional[datetime]) -> None:
-    value = timestamp
-    if value is not None and value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
+async def update_last_reaction_at(
+    account_id: int,
+    timestamp: Optional[datetime],
+) -> None:
+    """Persist the timestamp of the last reaction for an account.
+
+    The database expects a timezone-aware ``datetime`` value.  The function accepts
+    a :class:`datetime.datetime` object (or ``None`` to clear the column) and makes
+    sure the value is normalised to UTC before storing it.  Strings must be handled
+    by the caller – passing anything but ``datetime`` will raise a ``TypeError`` –
+    which protects the schema from accidentally storing serialised values.
+    """
+
+    if timestamp is None:
+        value: Optional[datetime] = None
+    elif not isinstance(timestamp, datetime):
+        raise TypeError("timestamp must be a datetime instance or None")
+    else:
+        if timestamp.tzinfo is None:
+            value = timestamp.replace(tzinfo=timezone.utc)
+        else:
+            value = timestamp.astimezone(timezone.utc)
+
     await _execute(
         """
         UPDATE accounts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,32 @@
+version: "3.9"
+
 services:
   postgres:
     image: postgres:15
-    container_name: ${PROJECT_NAME}_postgres
+    container_name: telegram_bot_postgres
+    hostname: postgres
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-${PROJECT_NAME}_db}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      - POSTGRES_DB=telegram_bot
+      - POSTGRES_USER=bot_user
+      - POSTGRES_PASSWORD=postgresbot1010
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init_database.sql:/docker-entrypoint-initdb.d/00_init_database.sql:ro
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "5432:5432"
     restart: unless-stopped
-    networks:
-      - project
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bot_user -d telegram_bot"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   bot:
     build: .
-    container_name: ${PROJECT_NAME}_bot
+    container_name: telegram_bot
+    hostname: bot
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${PROJECT_NAME}_postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-${PROJECT_NAME}_db}
+      - DATABASE_URL=postgresql://bot_user:postgresbot1010@postgres:5432/telegram_bot
     env_file:
       - .env
     volumes:
@@ -29,13 +37,8 @@ services:
     restart: unless-stopped
     user: "0:0"
     depends_on:
-      - postgres
-    networks:
-      - project
+      postgres:
+        condition: service_healthy
 
 volumes:
   postgres_data:
-
-networks:
-  project:
-    name: ${PROJECT_NAME}_network

--- a/init_database.sql
+++ b/init_database.sql
@@ -1,0 +1,193 @@
+-- Database bootstrap script for telegram warmup bot
+-- Ensures all required tables and seed data exist on a fresh deployment.
+
+CREATE TABLE IF NOT EXISTS users (
+    user_id BIGINT PRIMARY KEY,
+    is_authenticated BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    phone TEXT NOT NULL,
+    session_path TEXT NOT NULL,
+    chance INTEGER,
+    system_prompt TEXT,
+    sleep_min INTEGER,
+    sleep_max INTEGER,
+    reaction_emojis TEXT,
+    reaction_chance INTEGER,
+    reaction_discussion_chance INTEGER,
+    discussion_reply_prompt TEXT,
+    discussion_reply_chance INTEGER,
+    reaction_sleep_min INTEGER,
+    reaction_sleep_max INTEGER,
+    reaction_limit_per_message INTEGER,
+    last_reaction_at TIMESTAMPTZ,
+    channels TEXT,
+    warmup_channels TEXT,
+    status TEXT NOT NULL DEFAULT 'stopped',
+    last_started_at TIMESTAMPTZ,
+    last_stopped_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    mode TEXT NOT NULL DEFAULT 'warmup',
+    warmup_end_at TIMESTAMPTZ DEFAULT (CURRENT_TIMESTAMP + INTERVAL '7 days'),
+    warmup_joined_today INTEGER NOT NULL DEFAULT 0,
+    warmup_last_join DATE,
+    warmup_last_join_at TIMESTAMPTZ,
+    warmup_next_join_at TIMESTAMPTZ,
+    reactions_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    UNIQUE (user_id, phone),
+    CHECK (mode IN ('warmup', 'standard'))
+);
+
+CREATE TABLE IF NOT EXISTS account_settings (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    setting_key TEXT NOT NULL,
+    setting_value TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (account_id, setting_key)
+);
+
+CREATE TABLE IF NOT EXISTS warmup_channels (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    error TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at TIMESTAMPTZ,
+    joined_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (account_id, channel),
+    CHECK (status IN ('pending', 'joined', 'error'))
+);
+
+CREATE TABLE IF NOT EXISTS warmup_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    channels_per_day INTEGER NOT NULL,
+    delay_minutes INTEGER NOT NULL,
+    join_start_hour INTEGER NOT NULL,
+    join_start_minute INTEGER NOT NULL,
+    join_end_hour INTEGER NOT NULL,
+    join_end_minute INTEGER NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS comment_logs (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT,
+    message_id BIGINT,
+    status TEXT NOT NULL,
+    error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    post_id BIGINT NOT NULL,
+    message TEXT,
+    has_media BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(account_id, channel, post_id)
+);
+
+CREATE TABLE IF NOT EXISTS reaction_logs (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    message_id BIGINT NOT NULL,
+    emoji TEXT NOT NULL,
+    status TEXT NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS telegram_sessions (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    phone TEXT NOT NULL,
+    session_data BYTEA,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, phone)
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_settings_account_id ON account_settings (account_id);
+CREATE INDEX IF NOT EXISTS idx_warmup_channels_pending ON warmup_channels (account_id, status, position);
+CREATE INDEX IF NOT EXISTS idx_telegram_sessions_user_phone ON telegram_sessions (user_id, phone);
+CREATE INDEX IF NOT EXISTS idx_posts_account_id ON posts (account_id);
+CREATE INDEX IF NOT EXISTS idx_reaction_logs_account_id ON reaction_logs (account_id);
+CREATE INDEX IF NOT EXISTS idx_reaction_logs_channel_message ON reaction_logs (channel, message_id);
+
+INSERT INTO users (user_id, is_authenticated)
+VALUES (1, TRUE)
+ON CONFLICT (user_id) DO NOTHING;
+
+INSERT INTO accounts (
+    id,
+    user_id,
+    phone,
+    session_path,
+    status,
+    mode,
+    reactions_enabled,
+    reaction_emojis,
+    reaction_chance,
+    reaction_discussion_chance,
+    discussion_reply_chance,
+    reaction_sleep_min,
+    reaction_sleep_max,
+    reaction_limit_per_message,
+    sleep_min,
+    sleep_max,
+    chance
+) VALUES (
+    1,
+    1,
+    '+10000000000',
+    'sessions/1.session',
+    'running',
+    'standard',
+    TRUE,
+    '["❤️", "👍"]',
+    70,
+    80,
+    50,
+    30,
+    90,
+    8,
+    30,
+    90,
+    50
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO warmup_settings (
+    id,
+    channels_per_day,
+    delay_minutes,
+    join_start_hour,
+    join_start_minute,
+    join_end_hour,
+    join_end_minute
+) VALUES (
+    1,
+    5,
+    60,
+    10,
+    0,
+    20,
+    0
+)
+ON CONFLICT (id) DO NOTHING;

--- a/main.py
+++ b/main.py
@@ -867,8 +867,32 @@ async def _maybe_send_reaction(
         emoji: Optional[str] = None,
         error: Optional[str] = None,
     ) -> None:
+        message_identifier = message_id_int if message_id_int is not None else "unknown"
+
+        if status == "success":
+            logger.info(
+                "Reaction success for account=%s message=%s",
+                account_id,
+                message_identifier,
+            )
+        elif status == "failed":
+            logger.error(
+                "Reaction failed for account=%s message=%s: %s",
+                account_id,
+                message_identifier,
+                error,
+            )
+        elif status == "skipped":
+            logger.info(
+                "Reaction skipped for account=%s message=%s: %s",
+                account_id,
+                message_identifier,
+                error or "no reason provided",
+            )
+
         if message_id_int is None:
             return
+
         await add_reaction_log(
             account_id,
             channel=channel_for_reactions,
@@ -915,6 +939,7 @@ async def _maybe_send_reaction(
             account_id,
             message_id,
         )
+        await log_reaction_event("skipped", error="reactions disabled")
         return current_last_reaction_at, False
 
     if not reaction_emojis:
@@ -923,6 +948,7 @@ async def _maybe_send_reaction(
             account_id,
             message_id,
         )
+        await log_reaction_event("skipped", error="no reaction emojis configured")
         return current_last_reaction_at, False
 
     try:
@@ -959,6 +985,7 @@ async def _maybe_send_reaction(
             account_id,
             message_id,
         )
+        await log_reaction_event("skipped", error="reaction chance is zero")
         return current_last_reaction_at, False
 
     logger.info(
@@ -1052,6 +1079,11 @@ async def _maybe_send_reaction(
             await log_reaction_event("skipped", error=reason)
             return current_last_reaction_at, False
     else:
+        logger.info(
+            "Reaction approved for account=%s message=%s (forced mode)",
+            account_id,
+            message_id,
+        )
         logger.info(
             "Reaction forced for account=%s message=%s; bypassing chance roll",
             account_id,
@@ -1169,7 +1201,7 @@ async def _maybe_send_reaction(
             except (TypeError, ValueError):
                 message_identifier_int = getattr(message, "id", 0)
 
-            sent, error_text = await send_reaction_safe(
+            sent = await send_reaction_safe(
                 client,
                 message.chat.id,
                 int(message_identifier_int),
@@ -1206,12 +1238,12 @@ async def _maybe_send_reaction(
                     f"reaction invalid for emoji {reaction_emoji}: "
                     f"unsupported emojis {invalid_text}"
                 )
-                last_reaction_error_text = error_text or reason
-                logging.warning(
+                last_reaction_error_text = reason
+                logger.warning(
                     "Reaction invalid for chat %s with emojis %s: %s",
                     chat_id_for_reactions,
                     invalid_text,
-                    error_text,
+                    reason,
                 )
                 if working_reaction_emojis:
                     continue
@@ -1262,7 +1294,7 @@ async def _maybe_send_reaction(
         except Exception as reaction_error:
             last_reaction_error = reaction_error
             last_reaction_error_text = str(reaction_error)
-            logging.warning(
+            logger.warning(
                 "Attempt %s/%s failed to send reaction for %s: %s",
                 reaction_attempt,
                 max_reaction_attempts,
@@ -1276,6 +1308,14 @@ async def _maybe_send_reaction(
     if not reaction_sent and last_reaction_error is not None:
         error_text = last_reaction_error_text or str(last_reaction_error)
         attempts_text = attempts_performed or max_reaction_attempts
+        logger.error(
+            "Reaction failed for account=%s message=%s after %s attempts: %s",
+            account_id,
+            message_id,
+            attempts_text,
+            error_text,
+        )
+
         await bot.send_message(
             log_channel,
             (
@@ -1322,17 +1362,31 @@ def _message_has_media(message: Any) -> bool:
     return bool(media)
 
 
-async def send_reaction_safe(client: Client, chat_id: int, message_id: int, emoji: str) -> Tuple[bool, Optional[str]]:
+async def send_reaction_safe(client: Client, chat_id: int, message_id: int, emoji: str) -> bool:
+    """Send a quick reaction and return ``True`` on success.
+
+    Known ``REACTION_INVALID`` errors are converted into a ``False`` result so the
+    caller can try an alternative emoji without aborting the processing loop.  The
+    function keeps the logs informative while allowing unexpected errors to bubble
+    up for higher-level handling.
+    """
+
     try:
         await client.send_reaction(chat_id, message_id, emoji)
-        return True, None
+        logger.debug(
+            "Reaction request succeeded for chat=%s message=%s emoji=%s",
+            chat_id,
+            message_id,
+            emoji,
+        )
+        return True
     except ReactionInvalid as exc:
-        logging.warning("Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
-        return False, str(exc)
+        logger.warning("Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
+        return False
     except Exception as exc:
         if "REACTION_INVALID" in str(exc).upper():
-            logging.warning("Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
-            return False, str(exc)
+            logger.warning("Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
+            return False
         raise
 
 

--- a/test_reaction_logging_unit.py
+++ b/test_reaction_logging_unit.py
@@ -124,9 +124,8 @@ async def test_send_reaction_safe_handles_invalid():
 
     dummy = DummyClient()
 
-    sent, error = await send_reaction_safe(dummy, 1, 2, "🔥")
+    sent = await send_reaction_safe(dummy, 1, 2, "🔥")
     assert not sent
-    assert "REACTION_INVALID" in (error or "")
     assert events.sent
 
 
@@ -140,7 +139,6 @@ async def test_send_reaction_safe_success():
 
     dummy = DummyClient()
 
-    sent, error = await send_reaction_safe(dummy, 1, 2, "👍")
+    sent = await send_reaction_safe(dummy, 1, 2, "👍")
     assert sent
-    assert error is None
     assert events.sent


### PR DESCRIPTION
## Summary
- normalise stored reaction timestamps and guard against invalid values
- harden reaction workflow logging, emoji validation, and safe reaction sending logic
- add a database bootstrap script and update docker compose to initialise schema and seed defaults

## Testing
- pytest test_reaction_logging_unit.py

------
https://chatgpt.com/codex/tasks/task_e_68e7abc55d1c83308e1f3a9f284e36d3