### PR TITLE
Address review feedback for database bootstrap seed

### DIFF
--- a/init_database.sql
+++ b/init_database.sql
@@ -135,7 +135,6 @@ VALUES (1, TRUE)
 ON CONFLICT (user_id) DO NOTHING;
 
 INSERT INTO accounts (
-    id,
     user_id,
     phone,
     session_path,
@@ -154,7 +153,6 @@ INSERT INTO accounts (
     chance
 ) VALUES (
     1,
-    1,
     '+10000000000',
     'sessions/1.session',
     'running',
@@ -171,7 +169,7 @@ INSERT INTO accounts (
     90,
     50
 )
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (user_id, phone) DO NOTHING;
 
 INSERT INTO warmup_settings (
     id,


### PR DESCRIPTION
## Summary
- allow the seeded account to use the default sequence-generated id to avoid primary key conflicts

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e7b204fbac8330ae8239f4bf9402f4