### PR TITLE
Resolve account ID conflicts and improve reaction tracking

### DIFF
--- a/db.py
+++ b/db.py
@@ -583,21 +583,21 @@ async def is_user_authenticated(user_id: int) -> bool:
     return bool(row["is_authenticated"]) if row else False
 
 
-async def ensure_account(user_id: int, phone: str, session_path: str) -> Dict[str, Any]:
-    await _execute(
+async def ensure_account(user_id: int, phone: str, session_path: str) -> Optional[int]:
+    """Create or update an account and return its database identifier."""
+
+    row = await _fetchone(
         """
-        INSERT INTO accounts (user_id, phone, session_path)
-        VALUES (?, ?, ?)
+        INSERT INTO accounts (user_id, phone, session_path, status, mode)
+        VALUES (?, ?, ?, 'stopped', 'warmup')
         ON CONFLICT(user_id, phone) DO UPDATE SET
             session_path = excluded.session_path,
             updated_at = CURRENT_TIMESTAMP
+        RETURNING id
         """,
         (user_id, phone, session_path),
     )
-    account = await get_account_by_session(user_id, phone)
-    if account is None:  # pragma: no cover - defensive branch
-        raise RuntimeError("Failed to create or update account")
-    return account
+    return int(row["id"]) if row is not None else None
 
 
 async def _fetch_accounts(query: str, params: Iterable[Any]) -> List[Dict[str, Any]]:
@@ -824,26 +824,32 @@ async def bulk_update_reaction_settings(
 
 async def update_last_reaction_at(
     account_id: int,
-    timestamp: Optional[datetime],
+    reaction_time: Optional[Any],
 ) -> None:
     """Persist the timestamp of the last reaction for an account.
 
-    The database expects a timezone-aware ``datetime`` value.  The function accepts
-    a :class:`datetime.datetime` object (or ``None`` to clear the column) and makes
-    sure the value is normalised to UTC before storing it.  Strings must be handled
-    by the caller – passing anything but ``datetime`` will raise a ``TypeError`` –
-    which protects the schema from accidentally storing serialised values.
+    The function accepts timezone-aware :class:`datetime.datetime` objects,
+    naive datetimes (which are normalised to UTC) or ISO formatted strings.  The
+    relaxed parsing helps when external integrations provide serialized values
+    while keeping the column consistent in UTC.
     """
 
-    if timestamp is None:
+    if reaction_time is None:
         value: Optional[datetime] = None
-    elif not isinstance(timestamp, datetime):
-        raise TypeError("timestamp must be a datetime instance or None")
     else:
-        if timestamp.tzinfo is None:
-            value = timestamp.replace(tzinfo=timezone.utc)
+        dt_value: datetime
+        if isinstance(reaction_time, str):
+            normalised = reaction_time.replace("Z", "+00:00")
+            dt_value = datetime.fromisoformat(normalised)
+        elif isinstance(reaction_time, datetime):
+            dt_value = reaction_time
         else:
-            value = timestamp.astimezone(timezone.utc)
+            raise TypeError("reaction_time must be datetime, str or None")
+
+        if dt_value.tzinfo is None:
+            value = dt_value.replace(tzinfo=timezone.utc)
+        else:
+            value = dt_value.astimezone(timezone.utc)
 
     await _execute(
         """

--- a/init_database.sql
+++ b/init_database.sql
@@ -95,10 +95,10 @@ CREATE TABLE IF NOT EXISTS posts (
     id BIGSERIAL PRIMARY KEY,
     account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
     channel TEXT NOT NULL,
-    post_id BIGINT NOT NULL,
+    post_id INTEGER NOT NULL,
     message TEXT,
     has_media BOOLEAN DEFAULT FALSE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(account_id, channel, post_id)
 );
 
@@ -106,11 +106,11 @@ CREATE TABLE IF NOT EXISTS reaction_logs (
     id BIGSERIAL PRIMARY KEY,
     account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
     channel TEXT NOT NULL,
-    message_id BIGINT NOT NULL,
+    message_id INTEGER NOT NULL,
     emoji TEXT NOT NULL,
     status TEXT NOT NULL,
     error_message TEXT,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS telegram_sessions (
@@ -135,7 +135,6 @@ VALUES (1, TRUE)
 ON CONFLICT (user_id) DO NOTHING;
 
 INSERT INTO accounts (
-    id,
     user_id,
     phone,
     session_path,
@@ -152,8 +151,8 @@ INSERT INTO accounts (
     sleep_min,
     sleep_max,
     chance
-) VALUES (
-    1,
+)
+VALUES (
     1,
     '+10000000000',
     'sessions/1.session',
@@ -171,7 +170,7 @@ INSERT INTO accounts (
     90,
     50
 )
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (user_id, phone) DO NOTHING;
 
 INSERT INTO warmup_settings (
     id,
@@ -191,3 +190,18 @@ INSERT INTO warmup_settings (
     0
 )
 ON CONFLICT (id) DO NOTHING;
+
+UPDATE accounts SET 
+    status = 'running',
+    mode = 'standard',
+    reaction_chance = 70,
+    reaction_discussion_chance = 80,
+    discussion_reply_chance = 50,
+    discussion_reply_prompt = 'Ты молодец',
+    reaction_sleep_min = 30,
+    reaction_sleep_max = 90,
+    reaction_emojis = '["❤️", "👍"]',
+    reaction_limit_per_message = 8,
+    reactions_enabled = TRUE,
+    channels = '["@humormetahelp", "@man_about_womens", "@The_Womens_Psychology"]'
+WHERE phone = '79639791823';

--- a/main.py
+++ b/main.py
@@ -1363,30 +1363,20 @@ def _message_has_media(message: Any) -> bool:
 
 
 async def send_reaction_safe(client: Client, chat_id: int, message_id: int, emoji: str) -> bool:
-    """Send a quick reaction and return ``True`` on success.
-
-    Known ``REACTION_INVALID`` errors are converted into a ``False`` result so the
-    caller can try an alternative emoji without aborting the processing loop.  The
-    function keeps the logs informative while allowing unexpected errors to bubble
-    up for higher-level handling.
-    """
+    """Безопасно отправляет реакцию с обработкой ошибок."""
 
     try:
         await client.send_reaction(chat_id, message_id, emoji)
-        logger.debug(
-            "Reaction request succeeded for chat=%s message=%s emoji=%s",
-            chat_id,
-            message_id,
-            emoji,
-        )
+        logger.info("✅ Реакция %s отправлена на сообщение %s", emoji, message_id)
         return True
     except ReactionInvalid as exc:
-        logger.warning("Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
+        logger.warning("❌ Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
         return False
     except Exception as exc:
         if "REACTION_INVALID" in str(exc).upper():
-            logger.warning("Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
+            logger.warning("❌ Эмодзи %s не поддерживается в чате %s: %s", emoji, chat_id, exc)
             return False
+        logger.error("❌ Ошибка отправки реакции: %s", exc)
         raise
 
 

--- a/server_test_settings.py
+++ b/server_test_settings.py
@@ -63,16 +63,24 @@ async def test_settings_save():
             if session_dir and not os.path.exists(session_dir):
                 os.makedirs(session_dir, exist_ok=True)
 
-            account = await ensure_account(
+            account_id = await ensure_account(
                 DEFAULT_USER_ID,
                 DEFAULT_PHONE,
                 DEFAULT_SESSION_PATH,
             )
-            print(
-                "Создан аккаунт:\n"
-                f"  - ID: {account['id']}, Phone: {account['phone']}, User: {account['user_id']}"
-            )
-            all_accounts = [account]
+            if account_id is not None:
+                account = await get_account_by_id(account_id)
+            else:
+                account = None
+            if account:
+                print(
+                    "Создан аккаунт:\n"
+                    f"  - ID: {account['id']}, Phone: {account['phone']}, User: {account['user_id']}"
+                )
+                all_accounts = [account]
+            else:
+                print("Не удалось создать аккаунт")
+                return False
 
         # Используем первый найденный аккаунт
         test_account_id = all_accounts[0]["id"]

--- a/test_bot.py
+++ b/test_bot.py
@@ -49,21 +49,25 @@ async def test_get_global_statistics_and_report(tmp_path, monkeypatch):
     await db_module.init_db()
 
     await db_module.ensure_user(1)
-    account1 = await db_module.ensure_account(1, "+100", "sessions/1/+100.session")
-    account2 = await db_module.ensure_account(1, "+101", "sessions/1/+101.session")
-    account3 = await db_module.ensure_account(1, "+102", "sessions/1/+102.session")
+    account1_id = await db_module.ensure_account(1, "+100", "sessions/1/+100.session")
+    account2_id = await db_module.ensure_account(1, "+101", "sessions/1/+101.session")
+    account3_id = await db_module.ensure_account(1, "+102", "sessions/1/+102.session")
 
-    await db_module.mark_account_running(account1["id"])
-    await db_module.mark_account_running(account2["id"])
-    await db_module.set_account_mode(account2["id"], "standard", warmup_days=None)
+    assert account1_id is not None
+    assert account2_id is not None
+    assert account3_id is not None
 
-    await db_module.add_comment_log(account1["id"], channel="chat", message_id=1, status="success")
-    await db_module.add_comment_log(account1["id"], channel="chat", message_id=2, status="error", error="boom")
-    await db_module.add_comment_log(account2["id"], channel="chat", message_id=3, status="skipped", error="rnd")
-    await db_module.add_comment_log(account2["id"], channel="chat", message_id=4, status="no_comments", error="forbidden")
-    await db_module.add_comment_log(account2["id"], channel="chat", message_id=5, status="reaction_success")
-    await db_module.add_comment_log(account2["id"], channel="chat", message_id=6, status="reaction_error")
-    await db_module.add_comment_log(account3["id"], channel="chat", message_id=7, status="reaction_skipped")
+    await db_module.mark_account_running(account1_id)
+    await db_module.mark_account_running(account2_id)
+    await db_module.set_account_mode(account2_id, "standard", warmup_days=None)
+
+    await db_module.add_comment_log(account1_id, channel="chat", message_id=1, status="success")
+    await db_module.add_comment_log(account1_id, channel="chat", message_id=2, status="error", error="boom")
+    await db_module.add_comment_log(account2_id, channel="chat", message_id=3, status="skipped", error="rnd")
+    await db_module.add_comment_log(account2_id, channel="chat", message_id=4, status="no_comments", error="forbidden")
+    await db_module.add_comment_log(account2_id, channel="chat", message_id=5, status="reaction_success")
+    await db_module.add_comment_log(account2_id, channel="chat", message_id=6, status="reaction_error")
+    await db_module.add_comment_log(account3_id, channel="chat", message_id=7, status="reaction_skipped")
 
     conn = await db_module._require_conn()
     await conn.execute(
@@ -72,9 +76,9 @@ async def test_get_global_statistics_and_report(tmp_path, monkeypatch):
     )
     await conn.commit()
 
-    await db_module.sync_warmup_channels(account1["id"], ["@one", "@two"])
-    await db_module.mark_warmup_channel_joined(account1["id"], "@one")
-    await db_module.record_warmup_channel_error(account1["id"], "@two", "denied")
+    await db_module.sync_warmup_channels(account1_id, ["@one", "@two"])
+    await db_module.mark_warmup_channel_joined(account1_id, "@one")
+    await db_module.record_warmup_channel_error(account1_id, "@two", "denied")
 
     stats = await db_module.get_global_statistics()
 

--- a/test_comment_log_cleanup.py
+++ b/test_comment_log_cleanup.py
@@ -30,7 +30,8 @@ async def setup_database(tmp_path):
 @pytest.mark.anyio
 async def test_cleanup_comment_logs_removes_outdated_entries():
     await db.ensure_user(1)
-    account = await db.ensure_account(1, "+100500", "session.session")
+    account_id = await db.ensure_account(1, "+100500", "session.session")
+    assert account_id is not None
 
     conn = await db._require_conn()
     now = datetime.utcnow().replace(microsecond=0)
@@ -48,7 +49,7 @@ async def test_cleanup_comment_logs_removes_outdated_entries():
             VALUES (?, ?, ?, ?, ?, ?)
             """,
             (
-                account["id"],
+                account_id,
                 "test_channel",
                 message_id,
                 "test_status",

--- a/test_manage_warmup_channels.py
+++ b/test_manage_warmup_channels.py
@@ -226,9 +226,10 @@ def test_add_sleeps_syncs_subscriptions(monkeypatch, tmp_path):
     session_path = f"sessions/{user_id}/{phone}.session"
 
     asyncio.run(db.ensure_user(user_id))
-    account = asyncio.run(db.ensure_account(user_id, phone, session_path))
+    account_id = asyncio.run(db.ensure_account(user_id, phone, session_path))
+    assert account_id is not None
 
-    state = DummyState({"account": phone, "account_id": account["id"]})
+    state = DummyState({"account": phone, "account_id": account_id})
     message = DummyMessage("10-20", user_id=user_id)
 
     async def fake_check_account(user: int, session: str) -> bool:
@@ -291,7 +292,7 @@ def test_add_sleeps_syncs_subscriptions(monkeypatch, tmp_path):
 
     asyncio.run(main.add_sleeps(message, state))
 
-    updated_account = asyncio.run(db.get_account_by_id(account["id"]))
+    updated_account = asyncio.run(db.get_account_by_id(account_id))
     assert updated_account is not None
     assert recorded_calls == [], (recorded_calls, format_calls, sent_messages)
     assert format_calls == [], format_calls

--- a/test_reaction_logging_unit.py
+++ b/test_reaction_logging_unit.py
@@ -75,6 +75,10 @@ async def test_update_last_reaction_at_normalises_timezone(monkeypatch):
     assert calls[0][0].tzinfo is not None
     assert calls[0][1] == 3
 
+    await db.update_last_reaction_at(4, "2024-02-02T10:00:00Z")
+    assert calls[1][0].tzinfo is not None
+    assert calls[1][1] == 4
+
 
 @pytest.mark.anyio
 async def test_count_reactions_for_message_prefers_reaction_logs(monkeypatch):

--- a/test_settings_save.py
+++ b/test_settings_save.py
@@ -66,10 +66,11 @@ async def test_settings_save(tmp_path, monkeypatch):
 
     await db.init_db()
     await db.ensure_user(1)
-    account = await db.ensure_account(1, "79990000000", str(sessions_dir / "79990000000.session"))
+    account_id = await db.ensure_account(1, "79990000000", str(sessions_dir / "79990000000.session"))
+    assert account_id is not None
 
     await db.update_account_settings(
-        account_id=account["id"],
+        account_id=account_id,
         chance=30,
         system_prompt="Тестовый промпт для проверки",
         sleep_min=15,
@@ -81,7 +82,7 @@ async def test_settings_save(tmp_path, monkeypatch):
         reaction_emojis=["🔥", "👍"],
     )
 
-    stored = await db.get_account_by_id(account["id"])
+    stored = await db.get_account_by_id(account_id)
     assert stored["chance"] == 30
     assert stored["system_prompt"] == "Тестовый промпт для проверки"
     assert stored["sleep_min"] == 15


### PR DESCRIPTION
## Summary
- return account identifiers from `ensure_account` while keeping session updates intact
- normalise reaction timestamps from strings and update safe reaction logging
- extend database bootstrap to avoid fixed IDs, seed reaction settings, and align tests with new return type

## Testing
- `pytest test_reaction_logging_unit.py`
- `pytest` *(fails: DATABASE_URL must use the postgres scheme)*

------
https://chatgpt.com/codex/tasks/task_e_68e7b2e820a88330b195003e53b34443