### PR TITLE
Persist last reaction timestamp on reaction success

### DIFF
--- a/main.py
+++ b/main.py
@@ -886,6 +886,7 @@ async def _maybe_send_reaction(
             await client.send_reaction(message.chat.id, message.id, emoji)
 
             now = datetime.now(timezone.utc)
+            await update_last_reaction_at(account_id, now)
             await add_comment_log(
                 account_id,
                 channel=str(message.chat.id),


### PR DESCRIPTION
## Summary
- persist an account's last_reaction_at immediately after sending a reaction so cooldown data is not lost

## Testing
- python3 -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68e81171f8d48330a931b7f66a476ce8