### PR TITLE
Ensure PostgreSQL schema and defaults for reactions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,38 +1,21 @@
-# Project Configuration
-PROJECT_NAME=pgbot1010
+# Default environment configuration for the Telegram warmup bot
+# Copy this file to `.env` and adjust the values for your environment.
 
-# Docker Configuration
-POSTGRES_HOST=${PROJECT_NAME}_postgres
+# Project / Docker settings
+PROJECT_NAME=telegram_bot
+POSTGRES_DB=telegram_bot
+POSTGRES_USER=bot_user
+POSTGRES_PASSWORD=bot_password
 POSTGRES_PORT=5432
 
-# Database Configuration
-POSTGRES_DB=telegram_bot_${PROJECT_NAME}
-POSTGRES_USER=bot_user
-POSTGRES_PASSWORD=your_strong_password_here
-DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+# Bot configuration
+BOT_TOKEN=your_bot_token
+API_ID=123456
+API_HASH=0123456789abcdef0123456789abcdef
+OPENAI_API_KEY=sk-your-openai-key
+PASSWORD=change_me
+LOG_CHANNEL_ID=0
 
-# Telegram API Configuration
-BOT_TOKEN=your_bot_token_here
-API_ID=your_api_id_here
-API_HASH=your_api_hash_here
-
-# OpenAI Configuration (optional)
-OPENAI_API_KEY=your_openai_api_key_here
-
-# Application Settings
-PASSWORD=your_admin_password
-LOG_CHANNEL=your_log_channel_id
-ADMIN_IDS=your_admin_user_ids
-
-# Warmup Settings
-QUIET_START_HOUR=21
-QUIET_START_MINUTE=30
-QUIET_END_HOUR=4
-QUIET_END_MINUTE=30
-WARMUP_START_HOUR=1
-WARMUP_START_MINUTE=0
-WARMUP_END_HOUR=3
-WARMUP_END_MINUTE=0
-WARMUP_CHANNELS_PER_DAY=15
-WARMUP_DELAY_MINUTES=7
-WARMUP_DEFAULT_DAYS=7
+# Database connection string used by standalone scripts
+# (docker-compose will set DATABASE_URL for the bot container automatically)
+DATABASE_URL=postgresql://bot_user:bot_password@telegram_bot_postgres:5432/telegram_bot

--- a/README.md
+++ b/README.md
@@ -55,13 +55,16 @@
    # Для SQLite
    DATABASE_URL=sqlite:///data/CDXBOT0310.db
    # Для PostgreSQL
-   # DATABASE_URL=postgresql://user:password@host:5432/database
+   # DATABASE_URL=postgresql://bot_user:bot_password@telegram_bot_postgres:5432/telegram_bot
    ```
 
    Дополнительно доступны:
    - `WARMUP_VERBOSE_LOGS=1` — подробные логи в консоли.
    - `WARMUP_VERBOSE_NOTIFICATIONS=1` — расширенные уведомления в лог-канал.
    - `REACTION_LIMIT_PER_MESSAGE`, `REACTION_MIN_INTERVAL_SECONDS` — лимиты реакций.
+
+   > 💡 По умолчанию `docker-compose` создаёт базу данных `telegram_bot` с пользователем `bot_user`.
+   > Эти же значения используются в `.env.example` и в переменной `DATABASE_URL`.
 
 5. **Проверьте файл расписания `schedule.json`** — в нём задаются тихие периоды и окно прогрева. Значения по умолчанию:
    ```json

--- a/add_missing_tables.sql
+++ b/add_missing_tables.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS comment_logs (
     channel TEXT,
     message_id BIGINT,
     status TEXT NOT NULL,
+    error TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/create_all_tables.sql
+++ b/create_all_tables.sql
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS comment_logs (
     channel TEXT,
     message_id BIGINT,
     status TEXT NOT NULL,
+    error TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/db.py
+++ b/db.py
@@ -371,6 +371,50 @@ async def _init_postgres_schema() -> None:
 
         await connection.execute(
             """
+            CREATE TABLE IF NOT EXISTS posts (
+                id BIGSERIAL PRIMARY KEY,
+                account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                channel TEXT NOT NULL,
+                post_id INTEGER NOT NULL,
+                message TEXT,
+                has_media BOOLEAN DEFAULT FALSE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (account_id, channel, post_id)
+            )
+            """
+        )
+
+        await connection.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_posts_account_id
+            ON posts (account_id)
+            """
+        )
+
+        await connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reaction_logs (
+                id BIGSERIAL PRIMARY KEY,
+                account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                channel TEXT NOT NULL,
+                message_id INTEGER NOT NULL,
+                emoji TEXT NOT NULL,
+                status TEXT NOT NULL,
+                error_message TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+        await connection.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reaction_logs_account_id
+            ON reaction_logs (account_id)
+            """
+        )
+
+        await connection.execute(
+            """
             CREATE TABLE IF NOT EXISTS telegram_sessions (
                 id BIGSERIAL PRIMARY KEY,
                 user_id BIGINT NOT NULL,
@@ -1125,6 +1169,7 @@ async def add_comment_log(
     message_id: Optional[int],
     status: str,
     error: Optional[str] = None,
+    emoji: Optional[str] = None,
 ) -> None:
     await _execute(
         """
@@ -1133,6 +1178,23 @@ async def add_comment_log(
         """,
         (account_id, channel, message_id, status, error),
     )
+
+    if status.startswith("reaction_"):
+        reaction_status = status[len("reaction_") :]
+        base_status = reaction_status.split("_", 1)[0]
+        if base_status == "error":
+            normalized_status = "failed"
+        else:
+            normalized_status = base_status
+
+        await add_reaction_log(
+            account_id,
+            channel=channel,
+            message_id=message_id,
+            emoji=emoji,
+            status=normalized_status,
+            error_message=error,
+        )
 
 
 async def record_post(
@@ -1165,26 +1227,21 @@ async def record_post(
 async def add_reaction_log(
     account_id: int,
     *,
-    channel: str,
-    message_id: int,
+    channel: Optional[str],
+    message_id: Optional[int],
     emoji: Optional[str],
     status: str,
     error_message: Optional[str] = None,
 ) -> None:
     emoji_value = emoji if emoji else "N/A"
+    channel_value = channel or ""
+    message_value = message_id if message_id is not None else 0
     await _execute(
         """
         INSERT INTO reaction_logs (account_id, channel, message_id, emoji, status, error_message)
         VALUES (?, ?, ?, ?, ?, ?)
         """,
-        (
-            account_id,
-            channel,
-            message_id,
-            emoji_value,
-            status,
-            error_message,
-        ),
+        (account_id, channel_value, message_value, emoji_value, status, error_message),
     )
 
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,6 +12,13 @@ fi
 # Load environment
 source .env
 
+# Apply defaults if some variables are missing in .env
+PROJECT_NAME=${PROJECT_NAME:-telegram_bot}
+POSTGRES_DB=${POSTGRES_DB:-telegram_bot}
+POSTGRES_USER=${POSTGRES_USER:-bot_user}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-bot_password}
+POSTGRES_PORT=${POSTGRES_PORT:-5432}
+
 echo "📦 Project: $PROJECT_NAME"
 echo "🗄️ Database: $POSTGRES_DB"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - POSTGRES_DB=telegram_bot
       - POSTGRES_USER=bot_user
-      - POSTGRES_PASSWORD=postgresbot1010
+      - POSTGRES_PASSWORD=bot_password
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init_database.sql:/docker-entrypoint-initdb.d/00_init_database.sql:ro
@@ -26,7 +26,7 @@ services:
     container_name: telegram_bot
     hostname: bot
     environment:
-      - DATABASE_URL=postgresql://bot_user:postgresbot1010@postgres:5432/telegram_bot
+      - DATABASE_URL=postgresql://bot_user:bot_password@postgres:5432/telegram_bot
     env_file:
       - .env
     volumes:

--- a/main.py
+++ b/main.py
@@ -859,15 +859,31 @@ async def _maybe_send_reaction(
             )
             return current_last_reaction_at, False
 
-    if reaction_limit_per_message is not None and reaction_limit_per_message <= 0:
-        await add_comment_log(
-            account_id,
-            channel=str(getattr(getattr(message, 'chat', None), 'id', '')),
-            message_id=getattr(message, 'id', None),
-            status=f'reaction_skipped{status_suffix}',
-            error=f'reaction limit {reaction_limit_per_message} reached',
-        )
-        return current_last_reaction_at, True
+    channel_for_reactions = str(getattr(getattr(message, "chat", None), "id", ""))
+    message_identifier = getattr(message, "id", None)
+
+    if reaction_limit_per_message is not None:
+        if reaction_limit_per_message <= 0:
+            await add_comment_log(
+                account_id,
+                channel=channel_for_reactions,
+                message_id=message_identifier,
+                status=f'reaction_skipped{status_suffix}',
+                error=f'reaction limit {reaction_limit_per_message} reached',
+            )
+            return current_last_reaction_at, True
+
+        if channel_for_reactions and message_identifier is not None:
+            reaction_count = await count_reactions_for_message(channel_for_reactions, message_identifier)
+            if reaction_count >= reaction_limit_per_message:
+                await add_comment_log(
+                    account_id,
+                    channel=channel_for_reactions,
+                    message_id=message_identifier,
+                    status=f'reaction_skipped{status_suffix}',
+                    error=f'reaction limit {reaction_count}/{reaction_limit_per_message}',
+                )
+                return current_last_reaction_at, True
 
     working_emojis = list(reaction_emojis)
     max_attempts = 3
@@ -891,6 +907,7 @@ async def _maybe_send_reaction(
                 channel=str(message.chat.id),
                 message_id=message.id,
                 status=f'reaction_success{status_suffix}',
+                emoji=emoji,
             )
 
             reaction_link = post_base_link or _build_post_link(message, message)
@@ -915,6 +932,7 @@ async def _maybe_send_reaction(
                 message_id=message.id,
                 status=f'reaction_error{status_suffix}',
                 error=str(e),
+                emoji=emoji,
             )
             break
 

--- a/server_test_settings.py
+++ b/server_test_settings.py
@@ -10,7 +10,10 @@ import os
 # Добавляем текущую директорию в путь для импорта
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-os.environ.setdefault("DATABASE_URL", "sqlite:///CDXBOT0310.db")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql://bot_user:bot_password@localhost:5432/telegram_bot",
+)
 
 from db import (
     close_db,


### PR DESCRIPTION
## Summary
- align docker defaults and documentation around the `telegram_bot` database and sample environment configuration
- extend the PostgreSQL schema helpers to ensure `posts` and `reaction_logs` tables (with indexes) exist and log reactions with emoji metadata
- feed reaction events into `reaction_logs` via `add_comment_log`, enforcing per-message limits using the stored history

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8bfe65d1c83309c8ba9be8731c631