### PR TITLE
Add datetime serialization analysis

### DIFF
--- a/datetime_string_analysis.md
+++ b/datetime_string_analysis.md
@@ -1,0 +1,33 @@
+# Datetime serialization review
+
+This document captures the results of reviewing every function listed in the checklist for improper conversion of `datetime` instances to strings before executing SQL statements.
+
+## db.py
+
+### `db_update_warmup_schedule`
+* Parameters appended:
+  * `next_join` is appended directly without conversion.
+  * `last_join` is appended directly for `warmup_last_join_at`.
+  * `last_join.date()` is appended for `warmup_last_join`, yielding a `date` object (not a string).
+* **Result:** no string conversion; timestamps remain as `datetime` instances when passed to `_execute`. 【F:db.py†L1054-L1081】
+
+### `update_last_reaction_at`
+* Accepts `datetime`, ISO string, or `None`.
+* Parses ISO strings back into `datetime`, normalises to UTC, and passes the timezone-aware `datetime` instance to `_execute`.
+* **Result:** values reaching SQL remain `datetime` objects (or `None`), no string conversion. 【F:db.py†L877-L909】
+
+### Other UPDATE statements touching datetime columns
+* `update_account_settings` converts `datetime` to ISO format strings before updating `last_reaction_at`. 【F:db.py†L782-L787】
+* `set_account_mode` converts the computed `warmup_end_at` `datetime` to `target.isoformat()` before passing it to SQL. 【F:db.py†L919-L935】
+
+### `params.append(...)` with potential datetime values
+* `db_update_warmup_schedule` appends raw `datetime` objects (`next_join`, `last_join`) and a `date` object (`last_join.date()`). 【F:db.py†L1069-L1076】
+* `set_account_mode` appends `target.isoformat()` (string) when `warmup_days` is provided, converting the `datetime` to a string. 【F:db.py†L923-L935】
+
+## Summary
+* No conversions to string inside `db_update_warmup_schedule` or `update_last_reaction_at`.
+* Two remaining conversions to ISO strings were found:
+  1. `update_account_settings` when persisting `last_reaction_at` values.
+  2. `set_account_mode` when scheduling `warmup_end_at`.
+
+These should be revisited to ensure the database driver receives actual `datetime` objects if required by the backend.


### PR DESCRIPTION
## Summary
- add a report documenting how datetime values are handled in key database helpers
- highlight the remaining isoformat conversions that still pass strings to SQL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9119172648330904107915a3ff895