### PR TITLE
Fix async start/stop calls in safe_session_operation

### DIFF
--- a/main.py
+++ b/main.py
@@ -426,7 +426,7 @@ async def safe_session_operation(
                     )
                     raise
             else:
-                app.connect()
+                await app.start()
 
             entered_context = True
             connected_at = loop.time()
@@ -475,7 +475,7 @@ async def safe_session_operation(
                         else:
                             await app.__aexit__(None, None, None)
                     else:
-                        app.disconnect()
+                        await app.stop()
                 except asyncio.TimeoutError:
                     logging.error(
                         "safe_session_operation[%s]: timeout while closing client after %.2fs",


### PR DESCRIPTION
## Summary
- await `Client.start()` and `Client.stop()` when safe_session_operation is invoked with `start_client=False`
- ensure the client is properly started and stopped during authentication flows without context manager usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e94eb3453c8330a7b4ea00fef79ad0