### PR TITLE
Improve database bootstrapping resilience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@
 # Project / Docker settings
 PROJECT_NAME=telegram_bot
 POSTGRES_DB=telegram_bot
-POSTGRES_USER=bot_user
-POSTGRES_PASSWORD=bot_password
+POSTGRES_USER=pgbot1010_user
+POSTGRES_PASSWORD=pgbot1010_password
 POSTGRES_PORT=5432
 
 # Bot configuration
@@ -16,6 +16,8 @@ OPENAI_API_KEY=sk-your-openai-key
 PASSWORD=change_me
 LOG_CHANNEL_ID=0
 
-# Database connection string used by standalone scripts
-# (docker-compose will set DATABASE_URL for the bot container automatically)
-DATABASE_URL=postgresql://bot_user:bot_password@telegram_bot_postgres:5432/telegram_bot
+# Database connection string used by the bot and standalone scripts
+DATABASE_URL=postgresql://pgbot1010_user:pgbot1010_password@postgres:5432/pgbot1010
+
+# Optional admin connection string for automatic database/user creation scripts
+# DATABASE_ADMIN_URL=postgresql://postgres:postgres@postgres:5432/postgres

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
    # Для SQLite
    DATABASE_URL=sqlite:///data/CDXBOT0310.db
    # Для PostgreSQL
-   # DATABASE_URL=postgresql://bot_user:bot_password@telegram_bot_postgres:5432/telegram_bot
+   # DATABASE_URL=postgresql://pgbot1010_user:pgbot1010_password@postgres:5432/pgbot1010
    ```
 
    Дополнительно доступны:
@@ -63,7 +63,7 @@
    - `WARMUP_VERBOSE_NOTIFICATIONS=1` — расширенные уведомления в лог-канал.
    - `REACTION_LIMIT_PER_MESSAGE`, `REACTION_MIN_INTERVAL_SECONDS` — лимиты реакций.
 
-   > 💡 По умолчанию `docker-compose` создаёт базу данных `telegram_bot` с пользователем `bot_user`.
+   > 💡 По умолчанию `docker-compose` создаёт базу данных `pgbot1010` с пользователем `pgbot1010_user`.
    > Эти же значения используются в `.env.example` и в переменной `DATABASE_URL`.
 
 5. **Проверьте файл расписания `schedule.json`** — в нём задаются тихие периоды и окно прогрева. Значения по умолчанию:

--- a/check_database_integrity.py
+++ b/check_database_integrity.py
@@ -1,0 +1,43 @@
+import asyncio
+import logging
+import os
+
+from db import (
+    close_db,
+    ensure_default_warmup_settings,
+    ensure_warmup_settings_from_env,
+    init_db,
+    validate_database_integrity,
+)
+
+
+async def _run_check() -> int:
+    logging.basicConfig(level=logging.INFO)
+
+    if not os.getenv("DATABASE_URL"):
+        logging.error("DATABASE_URL environment variable must be set for the integrity check")
+        return 1
+
+    try:
+        await init_db()
+        await ensure_default_warmup_settings()
+        await ensure_warmup_settings_from_env()
+        if await validate_database_integrity():
+            logging.info("Database integrity check passed")
+            return 0
+        logging.error("Database integrity validation reported missing objects")
+        return 2
+    except Exception as exc:  # pragma: no cover - requires postgres
+        logging.exception("Database integrity check failed: %s", exc)
+        return 3
+    finally:
+        await close_db()
+
+
+def main() -> None:
+    exit_code = asyncio.run(_run_check())
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/db.py
+++ b/db.py
@@ -1,5 +1,6 @@
 import os
 import json
+import asyncio
 import importlib
 import importlib.util
 import logging
@@ -38,6 +39,28 @@ else:  # pragma: no cover - executed only when asyncpg is not installed
 _POOL: Optional[AsyncpgPool] = None
 _BACKEND: str = "postgres"
 _UNSET = object()
+
+_REQUIRED_TABLES = (
+    "public.users",
+    "public.accounts",
+    "public.account_settings",
+    "public.warmup_channels",
+    "public.warmup_settings",
+    "public.comment_logs",
+    "public.posts",
+    "public.reaction_logs",
+    "public.telegram_sessions",
+)
+
+_WARMUP_ENV_OVERRIDES = {
+    "WARMUP_CHANNELS_PER_DAY": "channels_per_day",
+    "WARMUP_DELAY_MINUTES": "delay_minutes",
+    "WARMUP_DEFAULT_DAYS": "default_days",
+    "WARMUP_JOIN_START_HOUR": "join_start_hour",
+    "WARMUP_JOIN_START_MINUTE": "join_start_minute",
+    "WARMUP_JOIN_END_HOUR": "join_end_hour",
+    "WARMUP_JOIN_END_MINUTE": "join_end_minute",
+}
 
 DEFAULT_REACTION_EMOJIS = ['❤️', '👍', '🔥', '🎉', '👏']
 
@@ -78,6 +101,17 @@ def _serialize_list(value: Optional[Iterable[str]]) -> Optional[str]:
     if value is None:
         return None
     return json.dumps(list(value))
+
+
+def _get_env_int_value(name: str) -> Optional[int]:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid integer value for %s: %s", name, raw)
+        return None
 
 
 def _require_pool() -> AsyncpgPool:
@@ -195,7 +229,7 @@ async def _fetchall(query: str, params: Sequence[Any] = ()):
         return await connection.fetch(prepared_query, *prepared_params)
 
 
-async def init_db() -> None:
+async def init_db(*, max_attempts: int = 5, initial_delay: float = 1.0) -> None:
     """Initialise database connection pool and ensure schema exists."""
 
     global _POOL, _BACKEND
@@ -217,9 +251,30 @@ async def init_db() -> None:
             "asyncpg is required for PostgreSQL connections. Install the 'asyncpg' package to use a PostgreSQL DSN."
         )
 
-    _POOL = await asyncpg.create_pool(dsn)
-    _BACKEND = "postgres"
-    await _init_postgres_schema()
+    attempt = 0
+    delay = max(initial_delay, 0.1)
+    last_error: Optional[BaseException] = None
+
+    while attempt < max_attempts:
+        attempt += 1
+        try:
+            _POOL = await asyncpg.create_pool(dsn)
+            _BACKEND = "postgres"
+            await ensure_schema_integrity()
+            logger.info("Database connection established on attempt %d", attempt)
+            return
+        except Exception as exc:  # pragma: no cover - requires postgres
+            last_error = exc
+            logger.exception("Database initialisation attempt %d failed: %s", attempt, exc)
+            if _POOL is not None:
+                await _POOL.close()
+                _POOL = None
+            if attempt >= max_attempts:
+                break
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 30.0)
+
+    raise RuntimeError("Failed to initialise PostgreSQL connection pool") from last_error
 
 async def _init_postgres_schema() -> None:
     pool = _require_pool()
@@ -314,12 +369,13 @@ async def _init_postgres_schema() -> None:
             """
             CREATE TABLE IF NOT EXISTS warmup_settings (
                 id INTEGER PRIMARY KEY CHECK (id = 1),
-                channels_per_day INTEGER NOT NULL,
-                delay_minutes INTEGER NOT NULL,
-                join_start_hour INTEGER NOT NULL,
-                join_start_minute INTEGER NOT NULL,
-                join_end_hour INTEGER NOT NULL,
-                join_end_minute INTEGER NOT NULL,
+                channels_per_day INTEGER NOT NULL DEFAULT 15,
+                delay_minutes INTEGER NOT NULL DEFAULT 7,
+                default_days INTEGER NOT NULL DEFAULT 7,
+                join_start_hour INTEGER NOT NULL DEFAULT 1,
+                join_start_minute INTEGER NOT NULL DEFAULT 0,
+                join_end_hour INTEGER NOT NULL DEFAULT 3,
+                join_end_minute INTEGER NOT NULL DEFAULT 0,
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
             )
             """
@@ -485,6 +541,71 @@ async def _init_postgres_schema() -> None:
             """
         )
 
+    await ensure_required_columns()
+
+
+async def _detect_missing_tables(connection: "asyncpg_type.connection.Connection") -> List[str]:
+    missing: List[str] = []
+    for table in _REQUIRED_TABLES:
+        exists = await connection.fetchval("SELECT to_regclass($1)", table)
+        if exists is None:
+            missing.append(table)
+    return missing
+
+
+async def recover_partial_schema(missing_tables: Optional[Sequence[str]] = None) -> None:
+    """Attempt to recreate missing tables using the declarative schema."""
+
+    if missing_tables:
+        logger.warning("Attempting schema recovery for tables: %s", ", ".join(missing_tables))
+    else:
+        logger.warning("Attempting schema recovery due to missing database objects")
+    await _init_postgres_schema()
+
+
+async def ensure_schema_integrity() -> None:
+    """Validate that all required tables exist, recovering if necessary."""
+
+    pool = _POOL
+    if pool is None:
+        raise DatabaseNotInitialized("init_db() must be called before ensure_schema_integrity().")
+
+    async with pool.acquire() as connection:
+        missing = await _detect_missing_tables(connection)
+
+    if missing:
+        await recover_partial_schema(missing)
+        async with pool.acquire() as connection:
+            remaining = await _detect_missing_tables(connection)
+        if remaining:
+            raise RuntimeError(
+                "Failed to initialise required database tables: " + ", ".join(remaining)
+            )
+    else:
+        logger.debug("All required tables are present in the database")
+
+    await ensure_required_columns()
+
+
+async def ensure_required_columns() -> None:
+    """Добавляет недостающие обязательные колонки в таблице warmup_settings."""
+
+    pool = _require_pool()
+
+    async with pool.acquire() as connection:
+        await connection.execute(
+            """
+            ALTER TABLE warmup_settings
+            ADD COLUMN IF NOT EXISTS channels_per_day INTEGER DEFAULT 15,
+            ADD COLUMN IF NOT EXISTS delay_minutes INTEGER DEFAULT 7,
+            ADD COLUMN IF NOT EXISTS default_days INTEGER DEFAULT 7,
+            ADD COLUMN IF NOT EXISTS join_start_hour INTEGER DEFAULT 1,
+            ADD COLUMN IF NOT EXISTS join_start_minute INTEGER DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS join_end_hour INTEGER DEFAULT 3,
+            ADD COLUMN IF NOT EXISTS join_end_minute INTEGER DEFAULT 0
+            """
+        )
+
 
 async def close_db() -> None:
     global _POOL
@@ -497,6 +618,7 @@ async def ensure_warmup_settings(
     *,
     channels_per_day: int,
     delay_minutes: int,
+    default_days: int,
     join_start_hour: int,
     join_start_minute: int,
     join_end_hour: int,
@@ -510,17 +632,19 @@ async def ensure_warmup_settings(
             id,
             channels_per_day,
             delay_minutes,
+            default_days,
             join_start_hour,
             join_start_minute,
             join_end_hour,
             join_end_minute
         )
-        VALUES (1, ?, ?, ?, ?, ?, ?)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO NOTHING
         """,
         (
             channels_per_day,
             delay_minutes,
+            default_days,
             join_start_hour,
             join_start_minute,
             join_end_hour,
@@ -536,6 +660,7 @@ async def get_warmup_settings() -> Dict[str, int]:
         """
         SELECT channels_per_day,
                delay_minutes,
+               default_days,
                join_start_hour,
                join_start_minute,
                join_end_hour,
@@ -548,20 +673,57 @@ async def get_warmup_settings() -> Dict[str, int]:
     if not row:
         raise RuntimeError("Warmup settings are not initialised")
 
+    row_data = dict(row)
+
     return {
-        "channels_per_day": int(row["channels_per_day"]),
-        "delay_minutes": int(row["delay_minutes"]),
-        "join_start_hour": int(row["join_start_hour"]),
-        "join_start_minute": int(row["join_start_minute"]),
-        "join_end_hour": int(row["join_end_hour"]),
-        "join_end_minute": int(row["join_end_minute"]),
+        "channels_per_day": int(row_data["channels_per_day"]),
+        "delay_minutes": int(row_data["delay_minutes"]),
+        "default_days": int(row_data.get("default_days", 7)),
+        "join_start_hour": int(row_data["join_start_hour"]),
+        "join_start_minute": int(row_data["join_start_minute"]),
+        "join_end_hour": int(row_data["join_end_hour"]),
+        "join_end_minute": int(row_data["join_end_minute"]),
     }
+
+
+async def ensure_default_warmup_settings() -> None:
+    """Ensure default warmup settings are present."""
+
+    try:
+        await ensure_warmup_settings(
+            channels_per_day=15,
+            delay_minutes=7,
+            default_days=7,
+            join_start_hour=1,
+            join_start_minute=0,
+            join_end_hour=3,
+            join_end_minute=0,
+        )
+    except Exception as exc:  # pragma: no cover - requires postgres
+        logger.error("Failed to ensure default warmup settings: %s", exc)
+
+
+async def ensure_warmup_settings_from_env() -> None:
+    """Override warmup settings using environment variables when provided."""
+
+    overrides: Dict[str, int] = {}
+    for env_name, column in _WARMUP_ENV_OVERRIDES.items():
+        value = _get_env_int_value(env_name)
+        if value is not None:
+            overrides[column] = value
+
+    if not overrides:
+        return
+
+    logger.info("Applying warmup settings overrides from environment: %s", overrides)
+    await update_warmup_settings(**overrides)
 
 
 async def update_warmup_settings(
     *,
     channels_per_day: Optional[int] = None,
     delay_minutes: Optional[int] = None,
+    default_days: Optional[int] = None,
     join_start_hour: Optional[int] = None,
     join_start_minute: Optional[int] = None,
     join_end_hour: Optional[int] = None,
@@ -580,6 +742,9 @@ async def update_warmup_settings(
     if delay_minutes is not None:
         updates.append("delay_minutes = ?")
         params.append(delay_minutes)
+    if default_days is not None:
+        updates.append("default_days = ?")
+        params.append(default_days)
     if join_start_hour is not None:
         updates.append("join_start_hour = ?")
         params.append(join_start_hour)
@@ -596,16 +761,25 @@ async def update_warmup_settings(
     if not updates:
         return
 
-    updates.append("updated_at = CURRENT_TIMESTAMP")
-    params.append(1)
-
     query = f"""
         UPDATE warmup_settings
-        SET {', '.join(updates)}
-        WHERE id = ?
+        SET {', '.join(updates)},
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = 1
     """
 
     await _execute(query, tuple(params))
+
+
+async def validate_database_integrity() -> bool:
+    """Run integrity checks and report status without raising."""
+
+    try:
+        await ensure_schema_integrity()
+    except Exception as exc:  # pragma: no cover - requires postgres
+        logger.error("Database integrity validation failed: %s", exc)
+        return False
+    return True
 
 
 async def ensure_user(user_id: int) -> None:

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,9 +14,9 @@ source .env
 
 # Apply defaults if some variables are missing in .env
 PROJECT_NAME=${PROJECT_NAME:-telegram_bot}
-POSTGRES_DB=${POSTGRES_DB:-telegram_bot}
-POSTGRES_USER=${POSTGRES_USER:-bot_user}
-POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-bot_password}
+POSTGRES_DB=${POSTGRES_DB:-pgbot1010}
+POSTGRES_USER=${POSTGRES_USER:-pgbot1010_user}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pgbot1010_password}
 POSTGRES_PORT=${POSTGRES_PORT:-5432}
 
 echo "📦 Project: $PROJECT_NAME"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "5432:5432"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bot_user -d telegram_bot"]
+      test: ["CMD-SHELL", "pg_isready -U pgbot1010_user -d pgbot1010 || pg_isready -U postgres -d pgbot1010"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -28,7 +28,7 @@ services:
     container_name: telegram_bot
     hostname: bot
     environment:
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/pgbot1010
+      - DATABASE_URL=postgresql://pgbot1010_user:pgbot1010_password@postgres:5432/pgbot1010
     env_file:
       - .env
     volumes:

--- a/init_database.sql
+++ b/init_database.sql
@@ -1,3 +1,165 @@
-CREATE USER bot_user WITH PASSWORD 'bot_password';
-CREATE DATABASE pgbot1010 OWNER bot_user;
-GRANT ALL PRIVILEGES ON DATABASE pgbot1010 TO bot_user;
+DO
+$$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbot1010_user') THEN
+        CREATE ROLE pgbot1010_user LOGIN PASSWORD 'pgbot1010_password';
+    END IF;
+END
+$$;
+
+DO
+$$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_database WHERE datname = 'pgbot1010') THEN
+        CREATE DATABASE pgbot1010 OWNER pgbot1010_user;
+    END IF;
+END
+$$;
+
+GRANT ALL PRIVILEGES ON DATABASE pgbot1010 TO pgbot1010_user;
+\c pgbot1010;
+
+CREATE TABLE IF NOT EXISTS users (
+    user_id BIGINT PRIMARY KEY,
+    is_authenticated BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    phone TEXT NOT NULL,
+    session_path TEXT NOT NULL,
+    chance INTEGER,
+    system_prompt TEXT,
+    sleep_min INTEGER,
+    sleep_max INTEGER,
+    reaction_emojis TEXT,
+    reaction_chance INTEGER,
+    reaction_discussion_chance INTEGER,
+    discussion_reply_prompt TEXT,
+    discussion_reply_chance INTEGER,
+    reaction_sleep_min INTEGER,
+    reaction_sleep_max INTEGER,
+    reaction_limit_per_message INTEGER,
+    last_reaction_at TIMESTAMPTZ,
+    channels TEXT,
+    warmup_channels TEXT,
+    status TEXT NOT NULL DEFAULT 'stopped',
+    last_started_at TIMESTAMPTZ,
+    last_stopped_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    mode TEXT NOT NULL DEFAULT 'warmup',
+    warmup_end_at TIMESTAMPTZ DEFAULT (CURRENT_TIMESTAMP + INTERVAL '7 days'),
+    warmup_joined_today INTEGER NOT NULL DEFAULT 0,
+    warmup_last_join DATE,
+    warmup_last_join_at TIMESTAMPTZ,
+    warmup_next_join_at TIMESTAMPTZ,
+    reactions_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    UNIQUE (user_id, phone),
+    CHECK (mode IN ('warmup', 'standard'))
+);
+
+CREATE TABLE IF NOT EXISTS account_settings (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    setting_key TEXT NOT NULL,
+    setting_value TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (account_id, setting_key)
+);
+
+CREATE TABLE IF NOT EXISTS warmup_channels (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    error TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at TIMESTAMPTZ,
+    joined_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (account_id, channel),
+    CHECK (status IN ('pending', 'joined', 'error'))
+);
+
+CREATE TABLE IF NOT EXISTS warmup_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    channels_per_day INTEGER NOT NULL DEFAULT 15,
+    delay_minutes INTEGER NOT NULL DEFAULT 7,
+    default_days INTEGER NOT NULL DEFAULT 7,
+    join_start_hour INTEGER NOT NULL DEFAULT 1,
+    join_start_minute INTEGER NOT NULL DEFAULT 0,
+    join_end_hour INTEGER NOT NULL DEFAULT 3,
+    join_end_minute INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO warmup_settings (
+    id,
+    channels_per_day,
+    delay_minutes,
+    default_days,
+    join_start_hour,
+    join_start_minute,
+    join_end_hour,
+    join_end_minute
+) VALUES (1, 15, 7, 7, 1, 0, 3, 0)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS comment_logs (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT,
+    message_id BIGINT,
+    status TEXT NOT NULL,
+    error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    post_id BIGINT NOT NULL,
+    message TEXT,
+    has_media BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (account_id, channel, post_id)
+);
+
+CREATE TABLE IF NOT EXISTS reaction_logs (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL,
+    message_id BIGINT NOT NULL,
+    emoji TEXT NOT NULL,
+    status TEXT NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS telegram_sessions (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    phone TEXT NOT NULL,
+    session_data BYTEA,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, phone)
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_settings_account_id ON account_settings (account_id);
+CREATE INDEX IF NOT EXISTS idx_warmup_channels_pending ON warmup_channels (account_id, status, position);
+CREATE INDEX IF NOT EXISTS idx_posts_account_id ON posts (account_id);
+CREATE INDEX IF NOT EXISTS idx_reaction_logs_account_id ON reaction_logs (account_id);
+CREATE INDEX IF NOT EXISTS idx_reaction_logs_channel_message ON reaction_logs (channel, message_id);
+CREATE INDEX IF NOT EXISTS idx_telegram_sessions_user_phone ON telegram_sessions (user_id, phone);
+
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO pgbot1010_user;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO pgbot1010_user;

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from datetime import datetime, time, timezone, timedelta
 from typing import Awaitable, Callable, Dict, List, Optional, Set, Any, Union, Tuple, AsyncIterator, IO
 from types import SimpleNamespace
+from urllib.parse import urlsplit
 import random
 import re
 from pyrogram import Client, filters
@@ -41,7 +42,8 @@ from db import (
     ensure_account,
     ensure_user,
     cleanup_comment_logs,
-    ensure_warmup_settings,
+    ensure_default_warmup_settings,
+    ensure_warmup_settings_from_env,
     get_account_by_id,
     get_account_by_session,
     get_accounts_for_user,
@@ -65,6 +67,7 @@ from db import (
     update_account_settings,
     update_last_reaction_at,
     update_warmup_settings,
+    validate_database_integrity,
     _require_pool,
 )
 
@@ -91,6 +94,20 @@ def load_env_file():
 
 # Load environment variables
 env_vars = load_env_file()
+
+
+def validate_env_config() -> None:
+    required_vars = ["BOT_TOKEN", "API_ID", "API_HASH", "DATABASE_URL"]
+    missing = [var for var in required_vars if not (env_vars.get(var) or os.getenv(var))]
+    if missing:
+        raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")
+    dsn = os.getenv("DATABASE_URL") or env_vars.get("DATABASE_URL")
+    if dsn:
+        parsed = urlsplit(dsn)
+        host = parsed.hostname or "<unknown>"
+        if parsed.port:
+            host = f"{host}:{parsed.port}"
+        logger.info("Environment configuration validated for database host %s", host)
 
 
 def _get_bool_env(name: str, default: bool = False) -> bool:
@@ -5226,26 +5243,39 @@ async def send_account_summary_to_logs(account_id, session_name):
     else:
         await bot.send_message(log_channel, f"❌ Не удалось получить информацию об аккаунте {session_name}")
 
+
+async def _initialise_database(log_file: IO[str]) -> None:
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            await init_db()
+            await ensure_default_warmup_settings()
+            await ensure_warmup_settings_from_env()
+
+            if not await validate_database_integrity():
+                raise RuntimeError("Database integrity validation failed")
+
+            logging.info("✅ Database initialized successfully")
+            log_file.write("Database initialized successfully\n")
+            log_file.flush()
+            return
+        except Exception as exc:
+            logger.error("Database initialization failed (attempt %d): %s", attempt, exc)
+            log_file.write(f"Database initialization failed (attempt {attempt}): {exc}\n")
+            log_file.flush()
+            await asyncio.sleep(min(5 * attempt, 60))
+
 async def main():
     try:
+        validate_env_config()
         _acquire_process_lock()
         with open("bot_log.txt", "w") as log_file:
             log_file.write("Starting bot initialization...\n")
             log_file.flush()
-            
-            await init_db()
-            await ensure_warmup_settings(
-                channels_per_day=DEFAULT_WARMUP_SETTINGS.channels_per_day,
-                delay_minutes=DEFAULT_WARMUP_SETTINGS.delay_minutes,
-                join_start_hour=DEFAULT_WARMUP_SETTINGS.join_start_hour,
-                join_start_minute=DEFAULT_WARMUP_SETTINGS.join_start_minute,
-                join_end_hour=DEFAULT_WARMUP_SETTINGS.join_end_hour,
-                join_end_minute=DEFAULT_WARMUP_SETTINGS.join_end_minute,
-            )
+
+            await _initialise_database(log_file)
             await ensure_latest_warmup_settings(force=True)
-            logging.info("✅ Database initialized successfully")
-            log_file.write("Database initialized successfully\n")
-            log_file.flush()
 
             deleted_logs = await cleanup_comment_logs(COMMENT_LOG_RETENTION_DAYS)
             logging.info("Удалено устаревших записей comment_logs при запуске: %d", deleted_logs)

--- a/server_test_settings.py
+++ b/server_test_settings.py
@@ -12,7 +12,7 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 os.environ.setdefault(
     "DATABASE_URL",
-    "postgresql://bot_user:bot_password@localhost:5432/telegram_bot",
+    "postgresql://pgbot1010_user:pgbot1010_password@localhost:5432/pgbot1010",
 )
 
 from db import (

--- a/test_settings_with_env.py
+++ b/test_settings_with_env.py
@@ -30,6 +30,7 @@ async def test_settings_save(tmp_path, monkeypatch):
     await db.ensure_warmup_settings(
         channels_per_day=15,
         delay_minutes=7,
+        default_days=7,
         join_start_hour=10,
         join_start_minute=0,
         join_end_hour=18,


### PR DESCRIPTION
## Summary
- add retry handling, schema integrity validation, and warmup default enforcement to the database bootstrap helpers
- validate required environment settings, wrap startup in a resilient database initialisation loop, and update Docker/init SQL assets to provision all objects with defaults
- provide a standalone database integrity check utility and update tests to include the new warmup default_days field

## Testing
- pytest test_settings_with_env.py *(fails: init_db requires a PostgreSQL DSN)*
- python -m compileall db.py main.py check_database_integrity.py

------
https://chatgpt.com/codex/tasks/task_e_68ecadf245dc8330aba04ab6240fc7fa