### PR TITLE
Persist user-level reaction settings

### DIFF
--- a/db.py
+++ b/db.py
@@ -278,6 +278,25 @@ async def _init_postgres_schema() -> None:
 
         await connection.execute(
             """
+            CREATE TABLE IF NOT EXISTS reaction_settings (
+                user_id BIGINT PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
+                reaction_chance INTEGER,
+                reaction_discussion_chance INTEGER,
+                discussion_reply_prompt TEXT,
+                discussion_reply_chance INTEGER,
+                reaction_sleep_min INTEGER,
+                reaction_sleep_max INTEGER,
+                reaction_emojis TEXT,
+                reaction_limit_per_message INTEGER,
+                reactions_enabled BOOLEAN,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+        await connection.execute(
+            """
             CREATE TABLE IF NOT EXISTS account_settings (
                 id BIGSERIAL PRIMARY KEY,
                 account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
@@ -618,6 +637,8 @@ async def ensure_user(user_id: int) -> None:
         (user_id,),
     )
 
+    await ensure_reaction_settings(user_id)
+
 
 async def set_user_authenticated(user_id: int, value: bool) -> None:
     await _execute(
@@ -810,6 +831,119 @@ async def update_account_settings(
     logger.debug("update_account_settings completed for account_id=%s", account_id)
 
 
+async def ensure_reaction_settings(user_id: int) -> None:
+    """Ensure that a reaction settings row exists for the given user."""
+
+    await _execute(
+        """
+        INSERT INTO reaction_settings (user_id)
+        VALUES (?)
+        ON CONFLICT(user_id) DO NOTHING
+        """,
+        (user_id,),
+    )
+
+
+async def get_reaction_settings_for_user(user_id: int) -> Dict[str, Any]:
+    """Fetch reaction settings for a user, returning an empty dict if missing."""
+
+    row = await _fetchone(
+        """
+        SELECT
+            reaction_chance,
+            reaction_discussion_chance,
+            discussion_reply_prompt,
+            discussion_reply_chance,
+            reaction_sleep_min,
+            reaction_sleep_max,
+            reaction_emojis,
+            reaction_limit_per_message,
+            reactions_enabled
+        FROM reaction_settings
+        WHERE user_id = ?
+        """,
+        (user_id,),
+    )
+
+    if not row:
+        return {}
+
+    data = dict(row)
+    data["reaction_emojis"] = _deserialize_list(data.get("reaction_emojis"))
+    reactions_enabled = data.get("reactions_enabled")
+    if reactions_enabled is not None:
+        data["reactions_enabled"] = bool(reactions_enabled)
+    return data
+
+
+async def update_reaction_settings(
+    user_id: int,
+    *,
+    reaction_chance: Any = _UNSET,
+    reaction_discussion_chance: Any = _UNSET,
+    discussion_reply_prompt: Any = _UNSET,
+    discussion_reply_chance: Any = _UNSET,
+    reaction_sleep_min: Any = _UNSET,
+    reaction_sleep_max: Any = _UNSET,
+    reaction_emojis: Any = _UNSET,
+    reaction_limit_per_message: Any = _UNSET,
+    reactions_enabled: Any = _UNSET,
+) -> None:
+    """Update or create reaction settings for a user."""
+
+    updates: List[str] = []
+    values: List[Any] = []
+
+    if reaction_chance is not _UNSET:
+        updates.append("reaction_chance = ?")
+        values.append(reaction_chance)
+    if reaction_discussion_chance is not _UNSET:
+        updates.append("reaction_discussion_chance = ?")
+        values.append(reaction_discussion_chance)
+    if discussion_reply_prompt is not _UNSET:
+        updates.append("discussion_reply_prompt = ?")
+        values.append(discussion_reply_prompt)
+    if discussion_reply_chance is not _UNSET:
+        updates.append("discussion_reply_chance = ?")
+        values.append(discussion_reply_chance)
+    if reaction_sleep_min is not _UNSET:
+        updates.append("reaction_sleep_min = ?")
+        values.append(reaction_sleep_min)
+    if reaction_sleep_max is not _UNSET:
+        updates.append("reaction_sleep_max = ?")
+        values.append(reaction_sleep_max)
+    if reaction_emojis is not _UNSET:
+        if reaction_emojis is None:
+            reaction_emojis = DEFAULT_REACTION_EMOJIS
+        updates.append("reaction_emojis = ?")
+        values.append(_serialize_list(reaction_emojis))
+    if reaction_limit_per_message is not _UNSET:
+        updates.append("reaction_limit_per_message = ?")
+        values.append(reaction_limit_per_message)
+    if reactions_enabled is not _UNSET:
+        updates.append("reactions_enabled = ?")
+        if reactions_enabled is None:
+            values.append(None)
+        else:
+            values.append(adapt_bool(bool(reactions_enabled)))
+
+    if not updates:
+        return
+
+    await ensure_reaction_settings(user_id)
+
+    updates.append("updated_at = CURRENT_TIMESTAMP")
+    values.append(user_id)
+
+    query = f"""
+        UPDATE reaction_settings
+        SET {', '.join(updates)}
+        WHERE user_id = ?
+    """
+
+    await _execute(query, tuple(values))
+
+
 async def bulk_update_reaction_settings(
     user_id: int,
     *,
@@ -870,6 +1004,29 @@ async def bulk_update_reaction_settings(
     """
 
     await _execute(query, tuple(values))
+
+    user_updates: Dict[str, Any] = {}
+    if reaction_chance is not None:
+        user_updates["reaction_chance"] = reaction_chance
+    if reaction_discussion_chance is not _UNSET:
+        user_updates["reaction_discussion_chance"] = reaction_discussion_chance
+    if discussion_reply_prompt is not _UNSET:
+        user_updates["discussion_reply_prompt"] = discussion_reply_prompt
+    if discussion_reply_chance is not _UNSET:
+        user_updates["discussion_reply_chance"] = discussion_reply_chance
+    if reaction_sleep_min is not None:
+        user_updates["reaction_sleep_min"] = reaction_sleep_min
+    if reaction_sleep_max is not None:
+        user_updates["reaction_sleep_max"] = reaction_sleep_max
+    if reaction_emojis is not None:
+        user_updates["reaction_emojis"] = reaction_emojis
+    if reaction_limit_per_message is not _UNSET:
+        user_updates["reaction_limit_per_message"] = reaction_limit_per_message
+    if reactions_enabled is not _UNSET:
+        user_updates["reactions_enabled"] = reactions_enabled
+
+    if user_updates:
+        await update_reaction_settings(user_id, **user_updates)
 
 
 async def update_last_reaction_at(

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ from db import (
     get_global_statistics,
     get_running_standard_accounts,
     get_running_accounts,
+    get_reaction_settings_for_user,
     get_warmup_pending,
     get_warmup_settings,
     increment_warmup_joined,
@@ -65,6 +66,7 @@ from db import (
     update_account_settings,
     update_last_reaction_at,
     update_warmup_settings,
+    update_reaction_settings,
     _require_pool,
 )
 
@@ -1220,14 +1222,15 @@ async def process_account_reactions(account: Dict[str, Any]) -> None:
         )
         return
 
-    reactions_enabled_raw = account.get("reactions_enabled")
-    reactions_enabled = True if reactions_enabled_raw is None else bool(reactions_enabled_raw)
+    resolved_reaction_settings = await _resolve_account_reaction_settings(account)
+
+    reactions_enabled = resolved_reaction_settings.get("reactions_enabled", True)
 
     if not reactions_enabled:
         logging.debug("Reactions disabled for account %s", account_id)
         return
 
-    reaction_emojis_raw = account.get("reaction_emojis") or []
+    reaction_emojis_raw = resolved_reaction_settings.get("reaction_emojis", [])
     reaction_emojis = [
         emoji.strip()
         for emoji in reaction_emojis_raw
@@ -1263,8 +1266,12 @@ async def process_account_reactions(account: Dict[str, Any]) -> None:
     else:
         session_name = session_path
 
-    reaction_sleep_min = _coerce_int(account.get("reaction_sleep_min"), 0)
-    reaction_sleep_max = _coerce_int(account.get("reaction_sleep_max"), 0)
+    reaction_sleep_min = _coerce_int(
+        resolved_reaction_settings.get("reaction_sleep_min"), 0
+    )
+    reaction_sleep_max = _coerce_int(
+        resolved_reaction_settings.get("reaction_sleep_max"), 0
+    )
 
     if reaction_sleep_min <= 0 or reaction_sleep_max <= 0:
         sleep_min_fallback = _coerce_int(account.get("sleep_min"), 10)
@@ -1277,11 +1284,15 @@ async def process_account_reactions(account: Dict[str, Any]) -> None:
     if reaction_sleep_min > reaction_sleep_max:
         reaction_sleep_min, reaction_sleep_max = reaction_sleep_max, reaction_sleep_min
 
-    reaction_limit_per_message = account.get("reaction_limit_per_message")
+    reaction_limit_per_message = resolved_reaction_settings.get(
+        "reaction_limit_per_message"
+    )
     if reaction_limit_per_message is None:
         reaction_limit_per_message = DEFAULT_REACTION_LIMIT_PER_MESSAGE
 
-    reaction_chance = _coerce_int(account.get("reaction_chance"), 0)
+    reaction_chance = _coerce_int(
+        resolved_reaction_settings.get("reaction_chance"), 0
+    )
 
     last_reaction_at = _parse_warmup_datetime(account.get("last_reaction_at"))
 
@@ -2990,6 +3001,56 @@ async def _load_account_data(state: FSMContext) -> Tuple[Dict[str, Any], Optiona
     return data, account_id, account
 
 
+async def _resolve_account_reaction_settings(account: Dict[str, Any]) -> Dict[str, Any]:
+    """Combine account-level and user-level reaction settings."""
+
+    user_settings: Dict[str, Any] = {}
+    user_id = account.get("user_id")
+
+    if user_id is not None:
+        try:
+            user_settings = await get_reaction_settings_for_user(user_id)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logging.exception(
+                "Failed to load reaction settings for user %s: %s",
+                user_id,
+                exc,
+            )
+            user_settings = {}
+
+    def _coalesce(key: str) -> Any:
+        value = account.get(key)
+        if value is None:
+            return user_settings.get(key)
+        return value
+
+    reaction_emojis_value = account.get("reaction_emojis")
+    if reaction_emojis_value is None:
+        reaction_emojis_value = user_settings.get("reaction_emojis")
+    if reaction_emojis_value is None:
+        reaction_emojis: List[str] = []
+    else:
+        reaction_emojis = list(reaction_emojis_value)
+
+    reactions_enabled_value = account.get("reactions_enabled")
+    if reactions_enabled_value is None:
+        reactions_enabled_value = user_settings.get("reactions_enabled")
+    if reactions_enabled_value is None:
+        reactions_enabled_value = True
+
+    return {
+        "reaction_emojis": reaction_emojis,
+        "reaction_chance": _coalesce("reaction_chance"),
+        "reaction_discussion_chance": _coalesce("reaction_discussion_chance"),
+        "discussion_reply_prompt": _coalesce("discussion_reply_prompt"),
+        "discussion_reply_chance": _coalesce("discussion_reply_chance"),
+        "reaction_sleep_min": _coalesce("reaction_sleep_min"),
+        "reaction_sleep_max": _coalesce("reaction_sleep_max"),
+        "reaction_limit_per_message": _coalesce("reaction_limit_per_message"),
+        "reactions_enabled": bool(reactions_enabled_value),
+    }
+
+
 def _format_chance(value: Optional[Union[int, str]]) -> str:
     if value is None:
         return "не задан"
@@ -3690,6 +3751,24 @@ async def _save_reaction_settings(
 
     await update_account_settings(account_id, **update_kwargs)
 
+    if target_user_id is not None:
+        user_update_kwargs: Dict[str, Any] = {}
+        for key in (
+            "reaction_chance",
+            "reaction_discussion_chance",
+            "discussion_reply_chance",
+            "discussion_reply_prompt",
+            "reaction_sleep_min",
+            "reaction_sleep_max",
+            "reaction_emojis",
+            "reaction_limit_per_message",
+        ):
+            if key in update_kwargs:
+                user_update_kwargs[key] = update_kwargs[key]
+
+        if user_update_kwargs:
+            await update_reaction_settings(target_user_id, **user_update_kwargs)
+
     if data.get("apply_reactions_to_all"):
         bulk_kwargs = dict(update_kwargs)
         bulk_user_id = target_user_id if target_user_id is not None else chat_id
@@ -3981,14 +4060,24 @@ async def send_comments(userid, session, account_id):
         chance = account.get("chance") or 100
 
         xsleep, ysleep = sleep_min, sleep_max
-        reaction_emojis: List[str] = account.get("reaction_emojis") or []
-        reaction_chance = account.get("reaction_chance")
+        resolved_reaction_settings = await _resolve_account_reaction_settings(account)
+        reaction_emojis_raw = resolved_reaction_settings.get("reaction_emojis", [])
+        reaction_emojis: List[str] = [
+            emoji.strip()
+            for emoji in reaction_emojis_raw
+            if isinstance(emoji, str) and emoji.strip()
+        ]
+        reaction_chance = resolved_reaction_settings.get("reaction_chance")
         if reaction_chance is None:
             reaction_chance = 0
-        reaction_discussion_chance = account.get("reaction_discussion_chance")
-        reaction_sleep_min = account.get("reaction_sleep_min")
-        reaction_sleep_max = account.get("reaction_sleep_max")
-        reaction_limit_per_message = account.get("reaction_limit_per_message")
+        reaction_discussion_chance = resolved_reaction_settings.get(
+            "reaction_discussion_chance"
+        )
+        reaction_sleep_min = resolved_reaction_settings.get("reaction_sleep_min")
+        reaction_sleep_max = resolved_reaction_settings.get("reaction_sleep_max")
+        reaction_limit_per_message = resolved_reaction_settings.get(
+            "reaction_limit_per_message"
+        )
         if reaction_limit_per_message is None:
             reaction_limit_per_message = DEFAULT_REACTION_LIMIT_PER_MESSAGE
         if reaction_sleep_min is None:
@@ -3998,10 +4087,13 @@ async def send_comments(userid, session, account_id):
         if reaction_sleep_min > reaction_sleep_max:
             reaction_sleep_min, reaction_sleep_max = reaction_sleep_max, reaction_sleep_min
 
-        discussion_reply_prompt = account.get("discussion_reply_prompt")
-        discussion_reply_chance = account.get("discussion_reply_chance")
-        reactions_enabled_raw = account.get("reactions_enabled")
-        reactions_enabled = True if reactions_enabled_raw is None else bool(reactions_enabled_raw)
+        discussion_reply_prompt = resolved_reaction_settings.get(
+            "discussion_reply_prompt"
+        )
+        discussion_reply_chance = resolved_reaction_settings.get(
+            "discussion_reply_chance"
+        )
+        reactions_enabled = resolved_reaction_settings.get("reactions_enabled", True)
 
         last_reaction_at_str = account.get("last_reaction_at")
         last_reaction_at_dt: Optional[datetime] = None

--- a/test_settings_save.py
+++ b/test_settings_save.py
@@ -111,6 +111,7 @@ async def test_reaction_settings_flow_saves_values(monkeypatch):
 
     captured_updates: list[tuple[int, dict[str, object]]] = []
     captured_bulk: list[tuple[int, dict[str, object]]] = []
+    captured_user_updates: list[tuple[int, dict[str, object]]] = []
     sent_messages: list[tuple[int, str]] = []
     main_message_called = False
 
@@ -123,6 +124,9 @@ async def test_reaction_settings_flow_saves_values(monkeypatch):
     async def fake_bulk_update(user: int, **kwargs):  # noqa: ANN001
         captured_bulk.append((user, kwargs))
 
+    async def fake_update_reaction_settings(user: int, **kwargs):  # noqa: ANN001
+        captured_user_updates.append((user, kwargs))
+
     async def fake_send_message(chat_id: int, text: str, **kwargs):  # noqa: ANN001
         sent_messages.append((chat_id, text))
         return types.SimpleNamespace(message_id=1)
@@ -134,6 +138,7 @@ async def test_reaction_settings_flow_saves_values(monkeypatch):
     monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
     monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
     monkeypatch.setattr(main, "bulk_update_reaction_settings", fake_bulk_update)
+    monkeypatch.setattr(main, "update_reaction_settings", fake_update_reaction_settings)
     monkeypatch.setattr(main.bot, "send_message", fake_send_message)
     monkeypatch.setattr(main, "main_message", fake_main_message)
 
@@ -171,6 +176,17 @@ async def test_reaction_settings_flow_saves_values(monkeypatch):
     assert kwargs["reaction_sleep_max"] == 4
     assert kwargs["reaction_emojis"] == ["🔥", "👍"]
     assert not captured_bulk, "Применение ко всем аккаунтам не должно вызываться без кнопки"
+    assert captured_user_updates, "Должны обновляться глобальные настройки реакций"
+    user_id_saved, user_kwargs = captured_user_updates[-1]
+    assert user_id_saved == user_id
+    assert user_kwargs["reaction_chance"] == 70
+    assert user_kwargs["reaction_discussion_chance"] == 50
+    assert user_kwargs["discussion_reply_chance"] == 100
+    assert user_kwargs["discussion_reply_prompt"] == "Промт"
+    assert user_kwargs["reaction_sleep_min"] == 2
+    assert user_kwargs["reaction_sleep_max"] == 4
+    assert user_kwargs["reaction_emojis"] == ["🔥", "👍"]
+    assert user_kwargs["reaction_limit_per_message"] == 10
     assert state.cleared is False
     assert main_message_called is False
     assert sent_messages, "Пользователь должен получить подтверждение сохранения"
@@ -220,9 +236,13 @@ async def test_reaction_settings_apply_all_triggers_bulk(monkeypatch):
         nonlocal main_message_called
         main_message_called = True
 
+    async def fake_update_reaction_settings(*args, **kwargs):  # noqa: ANN001
+        return None
+
     monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
     monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
     monkeypatch.setattr(main, "bulk_update_reaction_settings", fake_bulk_update)
+    monkeypatch.setattr(main, "update_reaction_settings", fake_update_reaction_settings)
     monkeypatch.setattr(main.bot, "send_message", fake_send_message)
     monkeypatch.setattr(main, "main_message", fake_main_message)
 
@@ -306,9 +326,13 @@ async def test_reaction_apply_all_notifies_user_from_bot_message(monkeypatch):
         nonlocal main_message_called
         main_message_called = True
 
+    async def fake_update_reaction_settings(*args, **kwargs):  # noqa: ANN001
+        return None
+
     monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
     monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
     monkeypatch.setattr(main, "bulk_update_reaction_settings", fake_bulk_update)
+    monkeypatch.setattr(main, "update_reaction_settings", fake_update_reaction_settings)
     monkeypatch.setattr(main.bot, "send_message", fake_send_message)
     monkeypatch.setattr(main, "main_message", fake_main_message)
 
@@ -377,9 +401,13 @@ async def test_reaction_apply_all_returns_main_menu_to_real_user(monkeypatch):
     async def fake_main_message(message):  # noqa: ANN001
         captured_main_messages.append(message)
 
+    async def fake_update_reaction_settings(*args, **kwargs):  # noqa: ANN001
+        return None
+
     monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
     monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
     monkeypatch.setattr(main, "bulk_update_reaction_settings", fake_bulk_update)
+    monkeypatch.setattr(main, "update_reaction_settings", fake_update_reaction_settings)
     monkeypatch.setattr(main.bot, "send_message", fake_send_message)
     monkeypatch.setattr(main, "main_message", fake_main_message)
 
@@ -438,9 +466,13 @@ async def test_reaction_settings_flow_with_defaults(monkeypatch):
     async def fake_main_message(message):  # noqa: ANN001
         return None
 
+    async def fake_update_reaction_settings(*args, **kwargs):  # noqa: ANN001
+        return None
+
     monkeypatch.setattr(main, "_load_account_data", fake_load_account_data)
     monkeypatch.setattr(main, "update_account_settings", fake_update_account_settings)
     monkeypatch.setattr(main, "bulk_update_reaction_settings", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main, "update_reaction_settings", fake_update_reaction_settings)
     monkeypatch.setattr(main.bot, "send_message", fake_send_message)
     monkeypatch.setattr(main, "main_message", fake_main_message)
 


### PR DESCRIPTION
## Summary
- add a dedicated `reaction_settings` table and helpers for persisting user-wide defaults alongside account settings
- merge account data with user defaults when scheduling reactions or sending comments so reactions honor the stored configuration
- ensure the reaction settings flow updates both account and user defaults and adjust tests to cover the new behaviour

## Testing
- pytest test_settings_save.py::test_reaction_settings_flow_saves_values -q
- pytest test_settings_save.py::test_reaction_settings_apply_all_triggers_bulk -q
- pytest test_settings_save.py::test_reaction_settings_flow_with_defaults -q

------
https://chatgpt.com/codex/tasks/task_e_68ece384cbd88330b767e9ede4ea21a3