### PR TITLE
Restore reaction tables and legacy session compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,43 @@
-# Default environment configuration for the Telegram warmup bot
-# Copy this file to `.env` and adjust the values for your environment.
+# === MULTI-INSTANCE CONFIGURATION ===
+# Бот и приложение
+BOT_NAME="YourBotName"
+CONTAINER_NAME="your_bot_instance"
+APP_PORT="8000"
 
-# Project / Docker settings
-PROJECT_NAME=telegram_bot
-POSTGRES_DB=telegram_bot
-POSTGRES_USER=bot_user
-POSTGRES_PASSWORD=bot_password
-POSTGRES_PORT=5432
+# База данных
+DB_NAME="your_db_name"
+DB_USER="your_db_user"
+DB_PASSWORD="your_secure_password"
+DB_PORT="5432"
 
-# Bot configuration
+# Директории (будут созданы автоматически)
+SESSIONS_DIR="sessions_instance"
+LOGS_DIR="logs_instance"
+DATA_DIR="data_instance"
+
+# === LEGACY COMPATIBILITY (optional) ===
+# Старые переменные для обратной совместимости
 BOT_TOKEN=your_bot_token
 API_ID=123456
 API_HASH=0123456789abcdef0123456789abcdef
 OPENAI_API_KEY=sk-your-openai-key
 PASSWORD=change_me
-LOG_CHANNEL_ID=0
+LOG_CHANNEL=-1000000000000
 
-# Database connection string used by standalone scripts
-# (docker-compose will set DATABASE_URL for the bot container automatically)
-DATABASE_URL=postgresql://bot_user:bot_password@telegram_bot_postgres:5432/telegram_bot
+# Time Settings
+QUIET_START_HOUR=21
+QUIET_START_MINUTE=30
+QUIET_END_HOUR=4
+QUIET_END_MINUTE=30
+
+# Warmup settings
+WARMUP_START_HOUR=1
+WARMUP_START_MINUTE=0
+WARMUP_END_HOUR=3
+WARMUP_END_MINUTE=0
+WARMUP_CHANNELS_PER_DAY=15
+WARMUP_DELAY_MINUTES=7
+WARMUP_DEFAULT_DAYS=7
+
+# === DATABASE URL (auto-generated or manual) ===
+# DATABASE_URL=postgresql://user:pass@host:port/dbname

--- a/db.py
+++ b/db.py
@@ -39,6 +39,20 @@ _POOL: Optional[AsyncpgPool] = None
 _BACKEND: str = "postgres"
 _UNSET = object()
 
+REQUIRED_TABLES = {
+    "users",
+    "accounts",
+    "comment_logs",
+    "reaction_settings",
+    "warmup_channels",
+    "warmup_logs",
+    "posts",
+}
+
+_ACCOUNT_SESSION_COLUMN = "session_path"
+_HAS_ACCOUNT_SESSION_PATH_COLUMN = True
+_HAS_ACCOUNT_NAME_COLUMN = False
+
 DEFAULT_REACTION_EMOJIS = ['❤️', '👍', '🔥', '🎉', '👏']
 
 
@@ -276,6 +290,8 @@ async def _init_postgres_schema() -> None:
             """
         )
 
+        await _synchronise_account_session_columns(connection)
+
         await connection.execute(
             """
             CREATE TABLE IF NOT EXISTS account_settings (
@@ -335,6 +351,20 @@ async def _init_postgres_schema() -> None:
                 status TEXT NOT NULL,
                 error TEXT,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+        await connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reaction_settings (
+                id BIGSERIAL PRIMARY KEY,
+                account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                setting_key TEXT NOT NULL,
+                setting_value TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (account_id, setting_key)
             )
             """
         )
@@ -429,6 +459,19 @@ async def _init_postgres_schema() -> None:
 
         await connection.execute(
             """
+            CREATE TABLE IF NOT EXISTS warmup_logs (
+                id BIGSERIAL PRIMARY KEY,
+                account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                channel TEXT,
+                status TEXT NOT NULL,
+                details TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+        await connection.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_account_settings_account_id
             ON account_settings (account_id)
             """
@@ -484,6 +527,63 @@ async def _init_postgres_schema() -> None:
             ADD COLUMN IF NOT EXISTS reactions_enabled BOOLEAN NOT NULL DEFAULT TRUE
             """
         )
+
+        await _verify_required_tables(connection)
+
+
+async def _synchronise_account_session_columns(connection: "asyncpg.connection.Connection") -> None:
+    """Ensure both legacy and new session columns exist and remain in sync."""
+
+    global _ACCOUNT_SESSION_COLUMN, _HAS_ACCOUNT_NAME_COLUMN, _HAS_ACCOUNT_SESSION_PATH_COLUMN
+
+    column_rows = await connection.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'accounts'
+        """
+    )
+    column_names = {row["column_name"] for row in column_rows}
+
+    has_session_path = "session_path" in column_names
+    has_name = "name" in column_names
+
+    if not has_session_path:
+        await connection.execute("ALTER TABLE accounts ADD COLUMN session_path TEXT")
+        has_session_path = True
+
+    if not has_name:
+        await connection.execute("ALTER TABLE accounts ADD COLUMN name TEXT")
+        has_name = True
+
+    await connection.execute(
+        "UPDATE accounts SET session_path = name WHERE session_path IS NULL AND name IS NOT NULL"
+    )
+    await connection.execute(
+        "UPDATE accounts SET name = session_path WHERE name IS NULL AND session_path IS NOT NULL"
+    )
+
+    _ACCOUNT_SESSION_COLUMN = "session_path" if has_session_path else "name"
+    _HAS_ACCOUNT_SESSION_PATH_COLUMN = has_session_path
+    _HAS_ACCOUNT_NAME_COLUMN = has_name
+
+
+async def _verify_required_tables(connection: "asyncpg.connection.Connection") -> None:
+    existing_rows = await connection.fetch(
+        """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_type = 'BASE TABLE' AND table_name = ANY($1::text[])
+        """,
+        list(REQUIRED_TABLES),
+    )
+    present_tables = {row["table_name"] for row in existing_rows}
+    missing = REQUIRED_TABLES - present_tables
+    if missing:
+        raise RuntimeError(
+            "Missing required database tables: " + ", ".join(sorted(missing))
+        )
+    logger.info("Verified required database tables: %s", sorted(present_tables))
 
 
 async def close_db() -> None:
@@ -634,17 +734,35 @@ async def is_user_authenticated(user_id: int) -> bool:
 async def ensure_account(user_id: int, phone: str, session_path: str) -> Optional[int]:
     """Create or update an account and return its database identifier."""
 
-    row = await _fetchone(
-        """
-        INSERT INTO accounts (user_id, phone, session_path, status, mode)
-        VALUES (?, ?, ?, 'stopped', 'warmup')
+    insert_columns: List[str] = ["user_id", "phone"]
+    insert_values: List[Any] = [user_id, phone]
+    update_clauses: List[str] = []
+
+    if _HAS_ACCOUNT_SESSION_PATH_COLUMN:
+        insert_columns.append("session_path")
+        insert_values.append(session_path)
+        update_clauses.append("session_path = excluded.session_path")
+
+    if _HAS_ACCOUNT_NAME_COLUMN:
+        insert_columns.append("name")
+        insert_values.append(session_path)
+        update_clauses.append("name = excluded.name")
+
+    insert_columns.extend(["status", "mode"])
+    insert_values.extend(["stopped", "warmup"])
+
+    placeholders = ", ".join("?" for _ in insert_values)
+    update_sql = ", ".join(update_clauses + ["updated_at = CURRENT_TIMESTAMP"])
+
+    query = f"""
+        INSERT INTO accounts ({', '.join(insert_columns)})
+        VALUES ({placeholders})
         ON CONFLICT(user_id, phone) DO UPDATE SET
-            session_path = excluded.session_path,
-            updated_at = CURRENT_TIMESTAMP
+            {update_sql}
         RETURNING id
-        """,
-        (user_id, phone, session_path),
-    )
+    """
+
+    row = await _fetchone(query, tuple(insert_values))
     return int(row["id"]) if row is not None else None
 
 
@@ -655,6 +773,11 @@ async def _fetch_accounts(query: str, params: Iterable[Any]) -> List[Dict[str, A
 
 def _convert_account_row(row: Any) -> Dict[str, Any]:
     data = dict(row)
+    session_path = data.get("session_path") or data.get("name") or data.get("session")
+    if session_path is not None:
+        data["session_path"] = session_path
+        if _HAS_ACCOUNT_NAME_COLUMN:
+            data.setdefault("name", session_path)
     data["channels"] = _deserialize_list(data.get("channels"))
     data["warmup_channels"] = _deserialize_list(data.get("warmup_channels"))
     data["reaction_emojis"] = _deserialize_list(data.get("reaction_emojis"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,20 +3,20 @@ version: "3.9"
 services:
   postgres:
     image: postgres:15
-    container_name: telegram_bot_postgres
+    container_name: ${CONTAINER_NAME}_postgres
     hostname: postgres
     environment:
-      - POSTGRES_DB=pgbot1010
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init_database.sql:/docker-entrypoint-initdb.d/00_init_database.sql:ro
     ports:
-      - "5432:5432"
+      - "${DB_PORT}:5432"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bot_user -d telegram_bot"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -25,17 +25,23 @@ services:
     tty: true
     stdin_open: true
     build: .
-    container_name: telegram_bot
+    container_name: ${CONTAINER_NAME}
     hostname: bot
     environment:
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/pgbot1010
+      - BOT_NAME=${BOT_NAME}
+      - SESSIONS_DIR=${SESSIONS_DIR}
+      - LOGS_DIR=${LOGS_DIR}
+      - DATA_DIR=${DATA_DIR}
+      - DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/${DB_NAME}
     env_file:
       - .env
     volumes:
-      - ./sessions:/app/sessions
-      - ./logs:/app/logs
+      - ./${SESSIONS_DIR}:/app/sessions
+      - ./${LOGS_DIR}:/app/logs
       - ./schedule.json:/app/schedule.json
-      - ./data:/app/data
+      - ./${DATA_DIR}:/app/data
+    ports:
+      - "${APP_PORT}:8000"
     restart: unless-stopped
     user: "0:0"
     depends_on:

--- a/init_database.sql
+++ b/init_database.sql
@@ -1,3 +1,41 @@
-CREATE USER bot_user WITH PASSWORD 'bot_password';
-CREATE DATABASE pgbot1010 OWNER bot_user;
-GRANT ALL PRIVILEGES ON DATABASE pgbot1010 TO bot_user;
+\set db_user `echo "$DB_USER" || echo "postgres"`
+\set db_password `echo "$DB_PASSWORD" || echo "postgres"`
+\set db_name `echo "$DB_NAME" || echo "pgbot1010"`
+
+CREATE USER :"db_user" WITH PASSWORD :'db_password';
+CREATE DATABASE :"db_name" OWNER :"db_user";
+GRANT ALL PRIVILEGES ON DATABASE :"db_name" TO :"db_user";
+
+\connect :"db_name"
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'accounts'
+    ) THEN
+        EXECUTE $$
+            CREATE TABLE IF NOT EXISTS reaction_settings (
+                id BIGSERIAL PRIMARY KEY,
+                account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                setting_key TEXT NOT NULL,
+                setting_value TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (account_id, setting_key)
+            )
+        $$;
+        EXECUTE $$
+            CREATE TABLE IF NOT EXISTS warmup_logs (
+                id BIGSERIAL PRIMARY KEY,
+                account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                channel TEXT,
+                status TEXT NOT NULL,
+                details TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        $$;
+    END IF;
+END
+$$;

--- a/main.py
+++ b/main.py
@@ -79,6 +79,8 @@ from db import (
 logger = logging.getLogger(__name__)
 from dotenv import load_dotenv
 
+load_dotenv()
+
 
 # Глобальные переменные для реакций
 REACTION_MIN_INTERVAL_SECONDS = 10  # ⚡ default fallback value, can be overridden via config
@@ -129,6 +131,15 @@ def load_env_file():
 env_vars = load_env_file()
 
 
+def _get_env(name: str, default: Optional[str] = None) -> Optional[str]:
+    value = env_vars.get(name)
+    if value is None:
+        value = os.getenv(name)
+    if value is None:
+        return default
+    return value
+
+
 def _get_bool_env(name: str, default: bool = False) -> bool:
     value = env_vars.get(name)
     if value is None:
@@ -151,14 +162,35 @@ def _get_int_env(name: str) -> Optional[int]:
         return None
 
 
-BOT_TOKEN = env_vars.get("BOT_TOKEN") or os.getenv("BOT_TOKEN")
+BOT_NAME = _get_env("BOT_NAME", "DefaultBot")
+SESSIONS_BASE_DIR = _get_env("SESSIONS_DIR", "sessions") or "sessions"
+LOGS_BASE_DIR = _get_env("LOGS_DIR", "logs") or "logs"
+DATA_BASE_DIR = _get_env("DATA_DIR", "data") or "data"
+
+for directory in (SESSIONS_BASE_DIR, LOGS_BASE_DIR, DATA_BASE_DIR):
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+DB_NAME = _get_env("DB_NAME", "pgbot1010")
+DB_USER = _get_env("DB_USER", "postgres")
+DB_PASSWORD = _get_env("DB_PASSWORD", "postgres")
+DB_HOST = _get_env("DB_HOST", "postgres")
+DB_PORT = _get_env("DB_PORT", "5432")
+
+DATABASE_URL = _get_env("DATABASE_URL")
+if not DATABASE_URL:
+    DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
+os.environ.setdefault("DATABASE_URL", DATABASE_URL)
+
+BOT_TOKEN = _get_env("BOT_TOKEN")
 print(f"BOT_TOKEN loaded: {BOT_TOKEN}")
 #APCDXBOT0310 @AP_comment_bot
 log_channel = -1003123025616 # cloveend #-1002711973256 #-1002678984799
 
-API_ID = int(env_vars.get("API_ID") or os.getenv("API_ID"))
+API_ID = int(_get_env("API_ID", "0"))
 print(f"API_ID loaded: {API_ID}")
-API_HASH = env_vars.get("API_HASH") or os.getenv("API_HASH")
+API_HASH = _get_env("API_HASH")
 print(f"API_HASH loaded: {API_HASH}")
 #1823
 
@@ -170,11 +202,30 @@ REACTION_MIN_INTERVAL_SECONDS = (
     _get_int_env("REACTION_MIN_INTERVAL_SECONDS") or REACTION_MIN_INTERVAL_SECONDS
 )
 
+
+def validate_configuration():
+    """Проверяет что все необходимые переменные окружения заданы"""
+
+    required_vars = ["BOT_TOKEN", "API_ID", "API_HASH"]
+    missing = [var for var in required_vars if not _get_env(var)]
+
+    if missing:
+        raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")
+
+    logging.info(f"Bot instance: {BOT_NAME}")
+    logging.info(f"Sessions directory: {SESSIONS_BASE_DIR}")
+    logging.info(f"Database: {_get_env('DB_NAME', 'pgbot1010')}")
+
 # Инициализация бота
+logging.basicConfig(
+    level=logging.DEBUG if WARMUP_VERBOSE_LOGS else logging.INFO,
+    format=f"[{BOT_NAME}] %(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+validate_configuration()
 bot = Bot(token=BOT_TOKEN)
 storage = MemoryStorage()
 dp = Dispatcher(storage=storage)
-logging.basicConfig(level=logging.DEBUG if WARMUP_VERBOSE_LOGS else logging.INFO)
+logger.info("Starting bot instance: %s", BOT_NAME)
 
 
 
@@ -2178,7 +2229,7 @@ async def check_account(user_id, phone):
                 _release_session_lock(key)
                 existing_client = None
 
-        session_base = f"sessions/{user_id}/{phone}"
+        session_base = os.path.join(SESSIONS_BASE_DIR, str(user_id), str(phone))
 
         async def _ensure_identity(app: Client) -> bool:
             identity_loop = asyncio.get_running_loop()
@@ -2328,9 +2379,9 @@ async def check_account(user_id, phone):
 async def main_message(message):
     user_id = message.from_user.id
     await ensure_user(user_id)
-    if not os.path.isdir("sessions"):
-        os.makedirs("sessions", exist_ok=True)
-    user_sessions_dir = os.path.join("sessions", str(user_id))
+    if not os.path.isdir(SESSIONS_BASE_DIR):
+        os.makedirs(SESSIONS_BASE_DIR, exist_ok=True)
+    user_sessions_dir = os.path.join(SESSIONS_BASE_DIR, str(user_id))
     if not os.path.isdir(user_sessions_dir):
         os.makedirs(user_sessions_dir, exist_ok=True)
 
@@ -2571,7 +2622,7 @@ async def clean_sessions_command(message: Message) -> None:
     """Команда для удаления .session.session файлов"""
     try:
         user_id = message.from_user.id
-        user_sessions_dir = os.path.join("sessions", str(user_id))
+        user_sessions_dir = os.path.join(SESSIONS_BASE_DIR, str(user_id))
         
         if not os.path.isdir(user_sessions_dir):
             await message.answer("❌ Директория сессий не найдена")
@@ -2863,8 +2914,8 @@ async def callbacks(callback_query: types.CallbackQuery, state: FSMContext):
         try:
             await delete_account(account_row["id"], account_row["phone"])
 
-            session_file = f"sessions/{user_id}/{session}.session"
-            session_file_alt = f"sessions/{user_id}/{session}.session.session"
+            session_file = os.path.join(SESSIONS_BASE_DIR, str(user_id), f"{session}.session")
+            session_file_alt = os.path.join(SESSIONS_BASE_DIR, str(user_id), f"{session}.session.session")
 
             deleted_files = []
             if os.path.exists(session_file):
@@ -3404,7 +3455,7 @@ async def _prepare_regular_channels_prompt(message: Message, state: FSMContext) 
     channels: List[str] = []
     seen_channels: Set[str] = set()
 
-    session_name = f"sessions/{message.from_user.id}/{session}"
+    session_name = os.path.join(SESSIONS_BASE_DIR, str(message.from_user.id), str(session))
     key = make_session_key(message.from_user.id, str(session))
 
     async def _collect_channels(app: Client) -> List[str]:
@@ -3975,7 +4026,7 @@ async def add_channels(message: Message, state: FSMContext) -> None:
     if str(message.text) != '-':
         channels = str(message.text).splitlines()
 
-        session_name = f"sessions/{message.from_user.id}/{session}"
+        session_name = os.path.join(SESSIONS_BASE_DIR, str(message.from_user.id), str(session))
         key = make_session_key(message.from_user.id, str(session))
 
         async def _manage_channels(app: Client) -> None:
@@ -4054,7 +4105,7 @@ async def add_channels(message: Message, state: FSMContext) -> None:
 async def send_comments(userid, session, account_id):
     async with account_semaphore:
         key = make_session_key(userid, session)
-        session_name = f"sessions/{userid}/{session}"
+        session_name = os.path.join(SESSIONS_BASE_DIR, str(userid), str(session))
 
         account = await get_account_by_id(account_id)
         if not account:
@@ -4193,7 +4244,7 @@ async def join_channel(
     """
     try:
         # Создаем клиент
-        session_dir = os.path.join("sessions", str(user_id))
+        session_dir = os.path.join(SESSIONS_BASE_DIR, str(user_id))
         session_name = os.path.join(session_dir, session_key)
         session_file = f"{session_name}.session"
 
@@ -4440,7 +4491,7 @@ async def process_warmup_accounts():
                 channel = channel_entry["channel"]
 
                 # Проверяем существование файла сессии
-                session_file = os.path.join("sessions", str(user_id), f"{session_key}.session")
+                session_file = os.path.join(SESSIONS_BASE_DIR, str(user_id), f"{session_key}.session")
                 if not os.path.exists(session_file):
                     warning_message = (
                         f"Аккаунт {session_key} (прогрев) - файл сессии не найден: {session_file}"
@@ -4537,7 +4588,7 @@ async def save_session_and_cleanup(
     client: Optional[Client],
     phone: str,
 ) -> None:
-    session_path = f"sessions/{message.from_user.id}/{phone}.session"
+    session_path = os.path.join(SESSIONS_BASE_DIR, str(message.from_user.id), f"{phone}.session")
     try:
         os.makedirs(os.path.dirname(session_path), exist_ok=True)
         await ensure_account(message.from_user.id, phone, session_path)
@@ -4577,7 +4628,7 @@ async def add_number(message: Message, state: FSMContext) -> None:
 
         client: Optional[Client] = None
         try:
-            session_name = f"sessions/{message.from_user.id}/{raw_number}"
+            session_name = os.path.join(SESSIONS_BASE_DIR, str(message.from_user.id), str(raw_number))
             os.makedirs(os.path.dirname(session_name), exist_ok=True)
 
             client = Client(
@@ -5420,7 +5471,7 @@ async def main():
                 user_id = account["user_id"]
                 phone = account["phone"]
                 key = make_session_key(user_id, phone)
-                session_file = os.path.join("sessions", str(user_id), f"{phone}.session")
+                session_file = os.path.join(SESSIONS_BASE_DIR, str(user_id), f"{phone}.session")
 
                 if os.path.exists(session_file):
                     # Перед повторным запуском очищаем прошлые записи, чтобы избежать дублирования

--- a/server_test_settings.py
+++ b/server_test_settings.py
@@ -28,7 +28,8 @@ from db import (
 
 DEFAULT_USER_ID = 291299155
 DEFAULT_PHONE = "+79999999999"
-DEFAULT_SESSION_PATH = "sessions/test.session"
+SESSIONS_BASE_DIR = os.getenv("SESSIONS_DIR", "sessions")
+DEFAULT_SESSION_PATH = os.path.join(SESSIONS_BASE_DIR, "test.session")
 
 async def test_settings_save():
     """Тестирует сохранение настроек аккаунта"""

--- a/test_account_start.py
+++ b/test_account_start.py
@@ -1,6 +1,10 @@
 import asyncio
 import logging
+import os
+
 logging.basicConfig(level=logging.DEBUG)
+
+SESSIONS_BASE_DIR = os.getenv("SESSIONS_DIR", "sessions")
 
 async def test_account_start():
     print("=== ТЕСТ ЗАПУСКА АККАУНТА ===")
@@ -33,8 +37,7 @@ async def test_account_start():
                     break
                     
             print("3. Проверяем файл сессии...")
-            import os
-            session_path = f"sessions/{user_id}/{test_account['phone']}.session"
+            session_path = os.path.join(SESSIONS_BASE_DIR, str(user_id), f"{test_account['phone']}.session")
             if os.path.exists(session_path):
                 print(f"   ✅ Файл сессии существует: {session_path}")
             else:

--- a/test_bot.py
+++ b/test_bot.py
@@ -9,6 +9,8 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv()
 
+SESSIONS_BASE_DIR = os.getenv("SESSIONS_DIR", "sessions")
+
 # Test environment variables
 bot_token = os.getenv("BOT_TOKEN")
 api_id = os.getenv("API_ID")
@@ -49,9 +51,21 @@ async def test_get_global_statistics_and_report(tmp_path, monkeypatch):
     await db_module.init_db()
 
     await db_module.ensure_user(1)
-    account1_id = await db_module.ensure_account(1, "+100", "sessions/1/+100.session")
-    account2_id = await db_module.ensure_account(1, "+101", "sessions/1/+101.session")
-    account3_id = await db_module.ensure_account(1, "+102", "sessions/1/+102.session")
+    account1_id = await db_module.ensure_account(
+        1,
+        "+100",
+        os.path.join(SESSIONS_BASE_DIR, "1", "+100.session"),
+    )
+    account2_id = await db_module.ensure_account(
+        1,
+        "+101",
+        os.path.join(SESSIONS_BASE_DIR, "1", "+101.session"),
+    )
+    account3_id = await db_module.ensure_account(
+        1,
+        "+102",
+        os.path.join(SESSIONS_BASE_DIR, "1", "+102.session"),
+    )
 
     assert account1_id is not None
     assert account2_id is not None

--- a/test_main_keyboard_layout.py
+++ b/test_main_keyboard_layout.py
@@ -8,6 +8,8 @@ os.environ.setdefault("API_ID", "1")
 os.environ.setdefault("API_HASH", "hash")
 os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
 
+SESSIONS_BASE_DIR = os.getenv("SESSIONS_DIR", "sessions")
+
 import main  # noqa: E402  pylint: disable=wrong-import-position
 
 
@@ -105,7 +107,7 @@ async def test_main_menu_keyboard_layout_no_accounts(monkeypatch):
 @pytest.mark.anyio
 async def test_main_menu_keyboard_layout_with_account_shows_reaction_button(monkeypatch):
     user_id = 123
-    session_file = os.path.normpath(f"sessions/{user_id}/79990000000.session")
+    session_file = os.path.normpath(os.path.join(SESSIONS_BASE_DIR, str(user_id), "79990000000.session"))
     existing_dirs: set[str] = set()
     existing_files: set[str] = {session_file}
 
@@ -127,7 +129,7 @@ async def test_main_menu_keyboard_layout_with_account_shows_reaction_button(monk
 
     def fake_listdir(path: str) -> list[str]:  # noqa: ARG001
         norm_path = _norm(path)
-        user_dir = _norm(f"sessions/{user_id}")
+        user_dir = _norm(os.path.join(SESSIONS_BASE_DIR, str(user_id)))
         if norm_path == user_dir:
             return ["79990000000.session"]
         return []

--- a/test_manage_warmup_channels.py
+++ b/test_manage_warmup_channels.py
@@ -8,6 +8,8 @@ os.environ.setdefault("API_ID", "1")
 os.environ.setdefault("API_HASH", "test")
 os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
 
+SESSIONS_BASE_DIR = os.getenv("SESSIONS_DIR", "sessions")
+
 import main
 import db
 
@@ -223,7 +225,7 @@ def test_add_sleeps_syncs_subscriptions(monkeypatch, tmp_path):
 
     user_id = 100
     phone = "71234567890"
-    session_path = f"sessions/{user_id}/{phone}.session"
+    session_path = os.path.join(SESSIONS_BASE_DIR, str(user_id), f"{phone}.session")
 
     asyncio.run(db.ensure_user(user_id))
     account_id = asyncio.run(db.ensure_account(user_id, phone, session_path))

--- a/test_session_file.py
+++ b/test_session_file.py
@@ -5,10 +5,13 @@ from pyrogram import Client
 
 logging.basicConfig(level=logging.DEBUG)
 
+SESSIONS_BASE_DIR = os.getenv("SESSIONS_DIR", "/app/sessions")
+
+
 async def test_session_file():
     user_id = 291299155
     phone = "79639791823"
-    session_path = f"/app/sessions/{user_id}/{phone}"
+    session_path = os.path.join(SESSIONS_BASE_DIR, str(user_id), phone)
     
     print(f"=== ДИАГНОСТИКА ФАЙЛА СЕССИИ {phone} ===")
     


### PR DESCRIPTION
## Summary
- sync legacy account session/name columns when initialising the PostgreSQL schema and while creating accounts
- centralise the required table list and reuse it for schema verification
- extend the database bootstrap script to provision the reaction_settings and warmup_logs tables when the database exists

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ef5449ee688330834681032eba515c