### PR TITLE
Align warmup processing with MSK timestamps

### DIFF
--- a/db.py
+++ b/db.py
@@ -47,6 +47,7 @@ REQUIRED_TABLES = {
     "warmup_logs",
     "posts",
     "channel_blacklist",
+    "warmup_settings",
 }
 
 DEFAULT_REACTION_EMOJIS = ['❤️', '👍', '🔥', '🎉', '👏']
@@ -542,6 +543,7 @@ async def _init_postgres_schema() -> None:
             "warmup_channels",
             "warmup_logs",
             "posts",
+            "warmup_settings",
         }
         existing = await connection.fetch(
             """
@@ -569,14 +571,24 @@ async def close_db() -> None:
 
 async def ensure_warmup_settings(
     *,
-    channels_per_day: int,
-    delay_minutes: int,
-    join_start_hour: int,
-    join_start_minute: int,
-    join_end_hour: int,
-    join_end_minute: int,
+    channels_per_day: int = 10,
+    delay_minutes: int = 30,
+    join_start_hour: int = 9,
+    join_start_minute: int = 0,
+    join_end_hour: int = 23,
+    join_end_minute: int = 0,
 ) -> None:
     """Ensure that a single warmup settings row exists in the database."""
+
+    logger.info(
+        "Ensuring warmup settings: %d channels/day, delay %d min, window %02d:%02d-%02d:%02d MSK",
+        channels_per_day,
+        delay_minutes,
+        join_start_hour,
+        join_start_minute,
+        join_end_hour,
+        join_end_minute,
+    )
 
     await _execute(
         """

--- a/main.py
+++ b/main.py
@@ -2137,9 +2137,9 @@ def load_schedule_config():
 
     default_config = {
         "quiet_period": {"start_hour": 8, "start_minute": 0, "end_hour": 20, "end_minute": 0},
-        "warmup_period": {"start_hour": 12, "start_minute": 0, "end_hour": 19, "end_minute": 0},
+        "warmup_period": {"start_hour": 9, "start_minute": 0, "end_hour": 23, "end_minute": 0},
         # Значения по умолчанию используются как резерв, реальные настройки читаются из БД
-        "warmup_settings": {"channels_per_day": 15, "delay_minutes": 7, "default_days": 7},
+        "warmup_settings": {"channels_per_day": 10, "delay_minutes": 30, "default_days": 7},
     }
 
     try:
@@ -2173,6 +2173,7 @@ QUIET_END_HOUR = SCHEDULE_CONFIG["quiet_period"]["end_hour"]
 QUIET_END_MINUTE = SCHEDULE_CONFIG["quiet_period"]["end_minute"]
 
 MOSCOW_UTC_OFFSET_MINUTES = 3 * 60
+MOSCOW_TZ = timezone(timedelta(hours=3))
 
 
 def _format_time_with_offset(hour: int, minute: int, offset_minutes: int = 0) -> str:
@@ -2259,6 +2260,25 @@ def format_warmup_settings(settings: WarmupSettingsData) -> str:
         f"• Окно вступлений: {settings.format_window()}\n"
         f"• Интервал между вступлениями (мин): {settings.delay_minutes}"
     )
+
+
+def get_moscow_time() -> datetime:
+    """Возвращает текущее время в московском часовом поясе."""
+
+    utc_now = datetime.now(timezone.utc)
+    return utc_now.astimezone(MOSCOW_TZ)
+
+
+def _to_moscow_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(MOSCOW_TZ)
+
+
+def _ensure_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _get_delay_bounds(settings: WarmupSettingsData) -> tuple[int, int]:
@@ -2389,29 +2409,35 @@ def _get_human_delay_seconds(settings: Optional[WarmupSettingsData] = None) -> i
 
 def _next_join_window_start(reference: datetime, settings: Optional[WarmupSettingsData] = None) -> datetime:
     settings = settings or get_current_warmup_settings()
-    start_time = settings.window_start
-    start = datetime.combine(reference.date(), start_time).replace(tzinfo=timezone.utc)
+    reference_utc = _ensure_utc_datetime(reference)
+    reference_moscow = reference_utc.astimezone(MOSCOW_TZ)
+
+    start_today = datetime.combine(
+        reference_moscow.date(),
+        settings.window_start,
+        tzinfo=MOSCOW_TZ,
+    )
 
     if settings.spans_midnight:
-        # Для окон через полночь следующий старт — сегодняшний вечер,
-        # если мы еще не достигли его, иначе +1 день
-        if reference.time() < settings.window_end and reference < start:
-            return start
-        if reference >= start:
-            return start + timedelta(days=1)
-        return start
+        if reference_moscow.time() < settings.window_end:
+            next_start = start_today
+        elif reference_moscow >= start_today:
+            next_start = start_today + timedelta(days=1)
+        else:
+            next_start = start_today
+    else:
+        if reference_moscow < start_today:
+            next_start = start_today
+        else:
+            next_start = start_today + timedelta(days=1)
 
-    if start <= reference:
-        start = datetime.combine(
-            reference.date() + timedelta(days=1),
-            start_time,
-        ).replace(tzinfo=timezone.utc)
-    return start
+    return next_start.astimezone(timezone.utc)
 
 
 def _warmup_window_duration(settings: WarmupSettingsData) -> timedelta:
-    start_dt = datetime.combine(datetime.now(timezone.utc).date(), settings.window_start)
-    end_dt = datetime.combine(datetime.now(timezone.utc).date(), settings.window_end)
+    today = get_moscow_time().date()
+    start_dt = datetime.combine(today, settings.window_start, tzinfo=MOSCOW_TZ)
+    end_dt = datetime.combine(today, settings.window_end, tzinfo=MOSCOW_TZ)
     duration = end_dt - start_dt
     if duration <= timedelta(0):
         duration += timedelta(days=1)
@@ -2419,22 +2445,35 @@ def _warmup_window_duration(settings: WarmupSettingsData) -> timedelta:
 
 
 def _resolve_window_start(reference: datetime, settings: WarmupSettingsData) -> datetime:
-    start_time = settings.window_start
-    base_start = datetime.combine(reference.date(), start_time).replace(tzinfo=timezone.utc)
+    reference_utc = _ensure_utc_datetime(reference)
+    reference_moscow = reference_utc.astimezone(MOSCOW_TZ)
+    start_today = datetime.combine(
+        reference_moscow.date(),
+        settings.window_start,
+        tzinfo=MOSCOW_TZ,
+    )
 
     if settings.spans_midnight:
-        if reference.time() < settings.window_end:
-            return base_start - timedelta(days=1)
-        if reference >= base_start:
-            return base_start
-        return base_start
+        if reference_moscow.time() < settings.window_end:
+            target_start = start_today - timedelta(days=1)
+        elif reference_moscow >= start_today:
+            target_start = start_today
+        else:
+            target_start = start_today
+    else:
+        end_today = datetime.combine(
+            reference_moscow.date(),
+            settings.window_end,
+            tzinfo=MOSCOW_TZ,
+        )
+        if reference_moscow < start_today:
+            target_start = start_today
+        elif reference_moscow >= end_today:
+            target_start = start_today + timedelta(days=1)
+        else:
+            target_start = start_today
 
-    end_dt = datetime.combine(reference.date(), settings.window_end).replace(tzinfo=timezone.utc)
-    if reference < base_start:
-        return base_start
-    if reference >= end_dt:
-        return base_start + timedelta(days=1)
-    return base_start
+    return target_start.astimezone(timezone.utc)
 
 
 def plan_next_warmup_join(earliest: datetime, settings: Optional[WarmupSettingsData] = None) -> datetime:
@@ -2485,9 +2524,14 @@ def is_quiet_period(now: datetime | None = None) -> bool:
 
 
 def is_warmup_sleep_period(now: datetime | None = None) -> bool:
-    """Проверяет, находимся ли мы в периоде сна для прогрева (настраивается через env)"""
-    now = now or datetime.now(timezone.utc)
-    current_time = now.time()
+    """Проверяет, находимся ли мы в периоде сна для прогрева (по времени МСК)."""
+
+    if now is None:
+        now_moscow = get_moscow_time()
+    else:
+        now_moscow = _to_moscow_datetime(now)
+
+    current_time = now_moscow.time()
     settings = get_current_warmup_settings()
     start = settings.window_start
     end = settings.window_end
@@ -2497,11 +2541,30 @@ def is_warmup_sleep_period(now: datetime | None = None) -> bool:
 
     return start <= current_time < end
 
+
 def is_warmup_join_period(now: datetime | None = None) -> bool:
-    """Проверяет, находимся ли мы в периоде для вступления в каналы прогрева (во время сна)"""
-    now = now or datetime.now(timezone.utc)
-    # Вступаем в каналы в период прогрева (12:00-19:00 UTC)
-    return is_warmup_sleep_period(now)
+    """Проверяет, находимся ли мы в периоде для вступления в каналы прогрева (по МСК)."""
+
+    if now is None:
+        now_moscow = get_moscow_time()
+    else:
+        now_moscow = _to_moscow_datetime(now)
+
+    current_settings = get_current_warmup_settings()
+    current_time = now_moscow.time()
+    start_time = time(
+        current_settings.join_start_hour,
+        current_settings.join_start_minute,
+    )
+    end_time = time(
+        current_settings.join_end_hour,
+        current_settings.join_end_minute,
+    )
+
+    if current_settings.spans_midnight:
+        return current_time >= start_time or current_time <= end_time
+
+    return start_time <= current_time <= end_time
 
 async def check_account(user_id, phone):
     key = make_session_key(user_id, phone)
@@ -4789,7 +4852,12 @@ async def process_single_warmup_account(
     logging.debug("Warmup: Processing account %s, active: %s", session_key, active_sessions.get(key))
     add_summary("debug", f"Processing account {session_key}, active={active_sessions.get(key)}")
 
-    now_utc = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now_moscow = now.replace(tzinfo=MOSCOW_TZ)
+    else:
+        now_moscow = now.astimezone(MOSCOW_TZ)
+    now_utc = now_moscow.astimezone(timezone.utc)
+    now_moscow_date = now_moscow.date()
 
     warmup_end = _parse_warmup_datetime(account.get("warmup_end_at"))
     if warmup_end and warmup_end.tzinfo is None:
@@ -4826,9 +4894,11 @@ async def process_single_warmup_account(
     else:
         account["warmup_last_join_at"] = warmup_last_join_at
 
-    if warmup_last_join_at and warmup_last_join_at.date() < now_utc.date():
-        await reset_warmup_daily_state(account_id)
-        account["warmup_joined_today"] = 0
+    if warmup_last_join_at:
+        last_join_moscow = warmup_last_join_at.astimezone(MOSCOW_TZ)
+        if last_join_moscow.date() < now_moscow_date:
+            await reset_warmup_daily_state(account_id)
+            account["warmup_joined_today"] = 0
 
     next_join_at = _parse_warmup_datetime(account.get("warmup_next_join_at"))
     if next_join_at and next_join_at.tzinfo is None:
@@ -4857,7 +4927,7 @@ async def process_single_warmup_account(
         message = f"Account {session_key} reached daily limit, skipping"
         logging.info("Warmup: %s", message)
         add_summary("info", message)
-        next_window_start = _next_join_window_start(now_utc, current_settings)
+        next_window_start = _next_join_window_start(now_moscow, current_settings)
         next_time = plan_next_warmup_join(next_window_start, current_settings)
         await db_update_warmup_schedule(account_id, next_join=next_time)
         logging.info(
@@ -4877,7 +4947,7 @@ async def process_single_warmup_account(
         message = f"Account {session_key} has no pending channels, skipping"
         logging.info("Warmup: %s", message)
         add_summary("info", message)
-        next_time = _get_next_warmup_join(now_utc, current_settings)
+        next_time = _get_next_warmup_join(now_moscow, current_settings)
         await db_update_warmup_schedule(account_id, next_join=next_time)
         logging.info(
             "Warmup schedule: account %s (%s) next join at %s",
@@ -4952,6 +5022,17 @@ async def process_single_warmup_account(
 async def process_warmup_accounts():
     """Фоновая задача для добавления каналов в режиме прогрева (во время сна)"""
 
+    try:
+        try:
+            from db import _require_pool as _ensure_pool_ready
+        except ImportError:
+            _ensure_pool_ready = _require_pool
+        _ensure_pool_ready()
+    except Exception as db_error:
+        logging.error("Database not ready for warmup: %s", db_error)
+        await asyncio.sleep(30)
+        return
+
     logging.info("✅ Processing warmup accounts...")
 
     while True:
@@ -4964,17 +5045,16 @@ async def process_warmup_accounts():
 
         try:
             current_settings = await ensure_latest_warmup_settings()
-            now = datetime.now(timezone.utc)
-            is_warmup_join_time = is_warmup_join_period(now)
+            now_moscow = get_moscow_time()
+            is_warmup_join_time = is_warmup_join_period(now_moscow)
             daily_limit = current_settings.channels_per_day
 
-            if now.minute % 10 == 0:
-                message = (
-                    f"Warmup check: {now.strftime('%H:%M')} UTC, "
-                    f"is_warmup_join_time: {is_warmup_join_time}"
-                )
-                logging.debug(message)
-                add_summary("debug", message)
+            warmup_check_message = (
+                f"Warmup check: {now_moscow.strftime('%H:%M')} МСК, "
+                f"is_warmup_join_time: {is_warmup_join_time}"
+            )
+            logging.info(warmup_check_message)
+            add_summary("info", warmup_check_message)
 
             if not is_warmup_join_time:
                 await asyncio.sleep(WARMUP_SCAN_INTERVAL_SECONDS)
@@ -4998,7 +5078,7 @@ async def process_warmup_accounts():
                 try:
                     await process_single_warmup_account(
                         account,
-                        now=now,
+                        now=now_moscow,
                         current_settings=current_settings,
                         daily_limit=daily_limit,
                         add_summary=add_summary,


### PR DESCRIPTION
## Summary
- ensure the warmup background task verifies the database pool before looping and propagates Moscow timestamps into account processing
- update individual warmup account handling to derive UTC values from Moscow time while resetting daily counters and planning joins in the MSK window
- log the warmup settings bootstrap so the seeded Moscow defaults are visible in startup diagnostics

## Testing
- pytest test_warmup_schedule.py *(fails: ImportError: cannot import name 'ChatWriteForbidden' from 'pyrogram.errors')*

------
https://chatgpt.com/codex/tasks/task_e_68f13ce93fe883308358daedcf87fe81