### PR TITLE
Fix warmup schema and auto-start warmup accounts

### DIFF
--- a/db.py
+++ b/db.py
@@ -47,6 +47,7 @@ REQUIRED_TABLES = {
     "warmup_logs",
     "posts",
     "channel_blacklist",
+    "warmup_settings",
 }
 
 DEFAULT_REACTION_EMOJIS = ['❤️', '👍', '🔥', '🎉', '👏']
@@ -306,7 +307,7 @@ async def _init_postgres_schema() -> None:
                 id BIGSERIAL PRIMARY KEY,
                 account_id BIGINT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
                 channel TEXT NOT NULL,
-                position INTEGER NOT NULL,
+                channel_username TEXT,
                 status TEXT NOT NULL DEFAULT 'pending',
                 error TEXT,
                 attempts INTEGER NOT NULL DEFAULT 0,
@@ -486,7 +487,56 @@ async def _init_postgres_schema() -> None:
         await connection.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_warmup_channels_pending
-            ON warmup_channels (account_id, status, position)
+            ON warmup_channels (account_id, status, created_at)
+            """
+        )
+
+        await connection.execute(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'warmup_channels' AND column_name = 'channel_id'
+                ) THEN
+                    ALTER TABLE warmup_channels RENAME COLUMN channel_id TO channel;
+                END IF;
+
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'warmup_channels' AND column_name = 'channel'
+                ) THEN
+                    ALTER TABLE warmup_channels ADD COLUMN channel TEXT;
+                END IF;
+
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'warmup_channels' AND column_name = 'channel' AND is_nullable = 'YES'
+                ) THEN
+                    UPDATE warmup_channels
+                    SET channel = COALESCE(channel, channel_username)
+                    WHERE channel IS NULL;
+                    UPDATE warmup_channels
+                    SET channel = ''
+                    WHERE channel IS NULL;
+                    ALTER TABLE warmup_channels ALTER COLUMN channel SET NOT NULL;
+                END IF;
+
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'warmup_channels' AND column_name = 'channel_username'
+                ) THEN
+                    ALTER TABLE warmup_channels ADD COLUMN channel_username TEXT;
+                END IF;
+
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'warmup_channels' AND column_name = 'position'
+                ) THEN
+                    ALTER TABLE warmup_channels DROP COLUMN position;
+                END IF;
+            END
+            $$;
             """
         )
 
@@ -542,6 +592,7 @@ async def _init_postgres_schema() -> None:
             "warmup_channels",
             "warmup_logs",
             "posts",
+            "warmup_settings",
         }
         existing = await connection.fetch(
             """
@@ -569,14 +620,24 @@ async def close_db() -> None:
 
 async def ensure_warmup_settings(
     *,
-    channels_per_day: int,
-    delay_minutes: int,
-    join_start_hour: int,
-    join_start_minute: int,
-    join_end_hour: int,
-    join_end_minute: int,
+    channels_per_day: int = 10,
+    delay_minutes: int = 30,
+    join_start_hour: int = 9,
+    join_start_minute: int = 0,
+    join_end_hour: int = 23,
+    join_end_minute: int = 0,
 ) -> None:
     """Ensure that a single warmup settings row exists in the database."""
+
+    logger.info(
+        "Ensuring warmup settings: %d channels/day, delay %d min, window %02d:%02d-%02d:%02d MSK",
+        channels_per_day,
+        delay_minutes,
+        join_start_hour,
+        join_start_minute,
+        join_end_hour,
+        join_end_minute,
+    )
 
     await _execute(
         """
@@ -1023,14 +1084,22 @@ async def sync_warmup_channels(account_id: int, channels: List[str]) -> None:
 
     await _execute("DELETE FROM warmup_channels WHERE account_id = ?", (account_id,))
 
-    for idx, channel in enumerate(unique_channels, start=1):
+    for raw_channel in unique_channels:
+        channel = (raw_channel or "").strip()
+        if not channel:
+            continue
+        username: Optional[str]
+        if channel.startswith("https://t.me/"):
+            username = channel.rsplit("/", 1)[-1] or None
+        else:
+            username = channel.lstrip("@") if channel.startswith("@") else channel or None
         try:
             await _execute(
                 """
-                INSERT INTO warmup_channels (account_id, channel, position)
+                INSERT INTO warmup_channels (account_id, channel, channel_username)
                 VALUES (?, ?, ?)
                 """,
-                (account_id, channel, idx),
+                (account_id, channel, username),
             )
         except AsyncpgUniqueViolationError:  # pragma: no cover - PostgreSQL duplicate guard
             continue
@@ -1051,10 +1120,20 @@ async def get_warmup_pending(
 ) -> List[Dict[str, Any]]:
     records = await _fetchall(
         """
-        SELECT *
+        SELECT id,
+               account_id,
+               channel,
+               channel_username,
+               status,
+               error,
+               attempts,
+               last_attempt_at,
+               joined_at,
+               created_at,
+               updated_at
         FROM warmup_channels
         WHERE account_id = ? AND status = 'pending'
-        ORDER BY position
+        ORDER BY created_at, id
         LIMIT ?
         """,
         (account_id, limit),
@@ -1070,10 +1149,20 @@ async def get_warmup_pending(
                 await sync_warmup_channels(account_id, queue)
                 records = await _fetchall(
                     """
-                    SELECT *
+                    SELECT id,
+                           account_id,
+                           channel,
+                           channel_username,
+                           status,
+                           error,
+                           attempts,
+                           last_attempt_at,
+                           joined_at,
+                           created_at,
+                           updated_at
                     FROM warmup_channels
                     WHERE account_id = ? AND status = 'pending'
-                    ORDER BY position
+                    ORDER BY created_at, id
                     LIMIT ?
                     """,
                     (account_id, limit),
@@ -1246,9 +1335,19 @@ async def get_running_warmup_accounts() -> List[Dict[str, Any]]:
 
 async def get_accounts_in_warmup() -> List[Dict[str, Any]]:
     return await _fetch_accounts(
-        "SELECT * FROM accounts WHERE mode = 'warmup' AND status = 'running'",
+        "SELECT * FROM accounts WHERE mode = 'warmup'",
         (),
     )
+
+
+async def auto_start_warmup_accounts() -> None:
+    """Ensure all warmup accounts are marked as running before scheduling joins."""
+
+    warmup_accounts = await get_accounts_in_warmup()
+    for account in warmup_accounts:
+        if account.get("status") != "running":
+            await mark_account_running(account["id"])
+            logger.info("Auto-started warmup account %s", account.get("phone", account["id"]))
 
 
 async def add_comment_log(

--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ from db import (
     get_account_by_session,
     get_accounts_for_user,
     get_global_statistics,
+    auto_start_warmup_accounts,
     get_running_standard_accounts,
     get_running_warmup_accounts,
     get_running_accounts,
@@ -2137,9 +2138,9 @@ def load_schedule_config():
 
     default_config = {
         "quiet_period": {"start_hour": 8, "start_minute": 0, "end_hour": 20, "end_minute": 0},
-        "warmup_period": {"start_hour": 12, "start_minute": 0, "end_hour": 19, "end_minute": 0},
+        "warmup_period": {"start_hour": 9, "start_minute": 0, "end_hour": 23, "end_minute": 0},
         # Значения по умолчанию используются как резерв, реальные настройки читаются из БД
-        "warmup_settings": {"channels_per_day": 15, "delay_minutes": 7, "default_days": 7},
+        "warmup_settings": {"channels_per_day": 10, "delay_minutes": 30, "default_days": 7},
     }
 
     try:
@@ -2173,6 +2174,7 @@ QUIET_END_HOUR = SCHEDULE_CONFIG["quiet_period"]["end_hour"]
 QUIET_END_MINUTE = SCHEDULE_CONFIG["quiet_period"]["end_minute"]
 
 MOSCOW_UTC_OFFSET_MINUTES = 3 * 60
+MOSCOW_TZ = timezone(timedelta(hours=3))
 
 
 def _format_time_with_offset(hour: int, minute: int, offset_minutes: int = 0) -> str:
@@ -2259,6 +2261,25 @@ def format_warmup_settings(settings: WarmupSettingsData) -> str:
         f"• Окно вступлений: {settings.format_window()}\n"
         f"• Интервал между вступлениями (мин): {settings.delay_minutes}"
     )
+
+
+def get_moscow_time() -> datetime:
+    """Возвращает текущее время в московском часовом поясе."""
+
+    utc_now = datetime.now(timezone.utc)
+    return utc_now.astimezone(MOSCOW_TZ)
+
+
+def _to_moscow_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(MOSCOW_TZ)
+
+
+def _ensure_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _get_delay_bounds(settings: WarmupSettingsData) -> tuple[int, int]:
@@ -2389,29 +2410,35 @@ def _get_human_delay_seconds(settings: Optional[WarmupSettingsData] = None) -> i
 
 def _next_join_window_start(reference: datetime, settings: Optional[WarmupSettingsData] = None) -> datetime:
     settings = settings or get_current_warmup_settings()
-    start_time = settings.window_start
-    start = datetime.combine(reference.date(), start_time).replace(tzinfo=timezone.utc)
+    reference_utc = _ensure_utc_datetime(reference)
+    reference_moscow = reference_utc.astimezone(MOSCOW_TZ)
+
+    start_today = datetime.combine(
+        reference_moscow.date(),
+        settings.window_start,
+        tzinfo=MOSCOW_TZ,
+    )
 
     if settings.spans_midnight:
-        # Для окон через полночь следующий старт — сегодняшний вечер,
-        # если мы еще не достигли его, иначе +1 день
-        if reference.time() < settings.window_end and reference < start:
-            return start
-        if reference >= start:
-            return start + timedelta(days=1)
-        return start
+        if reference_moscow.time() < settings.window_end:
+            next_start = start_today
+        elif reference_moscow >= start_today:
+            next_start = start_today + timedelta(days=1)
+        else:
+            next_start = start_today
+    else:
+        if reference_moscow < start_today:
+            next_start = start_today
+        else:
+            next_start = start_today + timedelta(days=1)
 
-    if start <= reference:
-        start = datetime.combine(
-            reference.date() + timedelta(days=1),
-            start_time,
-        ).replace(tzinfo=timezone.utc)
-    return start
+    return next_start.astimezone(timezone.utc)
 
 
 def _warmup_window_duration(settings: WarmupSettingsData) -> timedelta:
-    start_dt = datetime.combine(datetime.now(timezone.utc).date(), settings.window_start)
-    end_dt = datetime.combine(datetime.now(timezone.utc).date(), settings.window_end)
+    today = get_moscow_time().date()
+    start_dt = datetime.combine(today, settings.window_start, tzinfo=MOSCOW_TZ)
+    end_dt = datetime.combine(today, settings.window_end, tzinfo=MOSCOW_TZ)
     duration = end_dt - start_dt
     if duration <= timedelta(0):
         duration += timedelta(days=1)
@@ -2419,22 +2446,35 @@ def _warmup_window_duration(settings: WarmupSettingsData) -> timedelta:
 
 
 def _resolve_window_start(reference: datetime, settings: WarmupSettingsData) -> datetime:
-    start_time = settings.window_start
-    base_start = datetime.combine(reference.date(), start_time).replace(tzinfo=timezone.utc)
+    reference_utc = _ensure_utc_datetime(reference)
+    reference_moscow = reference_utc.astimezone(MOSCOW_TZ)
+    start_today = datetime.combine(
+        reference_moscow.date(),
+        settings.window_start,
+        tzinfo=MOSCOW_TZ,
+    )
 
     if settings.spans_midnight:
-        if reference.time() < settings.window_end:
-            return base_start - timedelta(days=1)
-        if reference >= base_start:
-            return base_start
-        return base_start
+        if reference_moscow.time() < settings.window_end:
+            target_start = start_today - timedelta(days=1)
+        elif reference_moscow >= start_today:
+            target_start = start_today
+        else:
+            target_start = start_today
+    else:
+        end_today = datetime.combine(
+            reference_moscow.date(),
+            settings.window_end,
+            tzinfo=MOSCOW_TZ,
+        )
+        if reference_moscow < start_today:
+            target_start = start_today
+        elif reference_moscow >= end_today:
+            target_start = start_today + timedelta(days=1)
+        else:
+            target_start = start_today
 
-    end_dt = datetime.combine(reference.date(), settings.window_end).replace(tzinfo=timezone.utc)
-    if reference < base_start:
-        return base_start
-    if reference >= end_dt:
-        return base_start + timedelta(days=1)
-    return base_start
+    return target_start.astimezone(timezone.utc)
 
 
 def plan_next_warmup_join(earliest: datetime, settings: Optional[WarmupSettingsData] = None) -> datetime:
@@ -2485,9 +2525,14 @@ def is_quiet_period(now: datetime | None = None) -> bool:
 
 
 def is_warmup_sleep_period(now: datetime | None = None) -> bool:
-    """Проверяет, находимся ли мы в периоде сна для прогрева (настраивается через env)"""
-    now = now or datetime.now(timezone.utc)
-    current_time = now.time()
+    """Проверяет, находимся ли мы в периоде сна для прогрева (по времени МСК)."""
+
+    if now is None:
+        now_moscow = get_moscow_time()
+    else:
+        now_moscow = _to_moscow_datetime(now)
+
+    current_time = now_moscow.time()
     settings = get_current_warmup_settings()
     start = settings.window_start
     end = settings.window_end
@@ -2497,11 +2542,30 @@ def is_warmup_sleep_period(now: datetime | None = None) -> bool:
 
     return start <= current_time < end
 
+
 def is_warmup_join_period(now: datetime | None = None) -> bool:
-    """Проверяет, находимся ли мы в периоде для вступления в каналы прогрева (во время сна)"""
-    now = now or datetime.now(timezone.utc)
-    # Вступаем в каналы в период прогрева (12:00-19:00 UTC)
-    return is_warmup_sleep_period(now)
+    """Проверяет, находимся ли мы в периоде для вступления в каналы прогрева (по МСК)."""
+
+    if now is None:
+        now_moscow = get_moscow_time()
+    else:
+        now_moscow = _to_moscow_datetime(now)
+
+    current_settings = get_current_warmup_settings()
+    current_time = now_moscow.time()
+    start_time = time(
+        current_settings.join_start_hour,
+        current_settings.join_start_minute,
+    )
+    end_time = time(
+        current_settings.join_end_hour,
+        current_settings.join_end_minute,
+    )
+
+    if current_settings.spans_midnight:
+        return current_time >= start_time or current_time <= end_time
+
+    return start_time <= current_time <= end_time
 
 async def check_account(user_id, phone):
     key = make_session_key(user_id, phone)
@@ -4789,7 +4853,12 @@ async def process_single_warmup_account(
     logging.debug("Warmup: Processing account %s, active: %s", session_key, active_sessions.get(key))
     add_summary("debug", f"Processing account {session_key}, active={active_sessions.get(key)}")
 
-    now_utc = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now_moscow = now.replace(tzinfo=MOSCOW_TZ)
+    else:
+        now_moscow = now.astimezone(MOSCOW_TZ)
+    now_utc = now_moscow.astimezone(timezone.utc)
+    now_moscow_date = now_moscow.date()
 
     warmup_end = _parse_warmup_datetime(account.get("warmup_end_at"))
     if warmup_end and warmup_end.tzinfo is None:
@@ -4826,9 +4895,11 @@ async def process_single_warmup_account(
     else:
         account["warmup_last_join_at"] = warmup_last_join_at
 
-    if warmup_last_join_at and warmup_last_join_at.date() < now_utc.date():
-        await reset_warmup_daily_state(account_id)
-        account["warmup_joined_today"] = 0
+    if warmup_last_join_at:
+        last_join_moscow = warmup_last_join_at.astimezone(MOSCOW_TZ)
+        if last_join_moscow.date() < now_moscow_date:
+            await reset_warmup_daily_state(account_id)
+            account["warmup_joined_today"] = 0
 
     next_join_at = _parse_warmup_datetime(account.get("warmup_next_join_at"))
     if next_join_at and next_join_at.tzinfo is None:
@@ -4857,7 +4928,7 @@ async def process_single_warmup_account(
         message = f"Account {session_key} reached daily limit, skipping"
         logging.info("Warmup: %s", message)
         add_summary("info", message)
-        next_window_start = _next_join_window_start(now_utc, current_settings)
+        next_window_start = _next_join_window_start(now_moscow, current_settings)
         next_time = plan_next_warmup_join(next_window_start, current_settings)
         await db_update_warmup_schedule(account_id, next_join=next_time)
         logging.info(
@@ -4877,7 +4948,7 @@ async def process_single_warmup_account(
         message = f"Account {session_key} has no pending channels, skipping"
         logging.info("Warmup: %s", message)
         add_summary("info", message)
-        next_time = _get_next_warmup_join(now_utc, current_settings)
+        next_time = _get_next_warmup_join(now_moscow, current_settings)
         await db_update_warmup_schedule(account_id, next_join=next_time)
         logging.info(
             "Warmup schedule: account %s (%s) next join at %s",
@@ -4952,6 +5023,17 @@ async def process_single_warmup_account(
 async def process_warmup_accounts():
     """Фоновая задача для добавления каналов в режиме прогрева (во время сна)"""
 
+    try:
+        try:
+            from db import _require_pool as _ensure_pool_ready
+        except ImportError:
+            _ensure_pool_ready = _require_pool
+        _ensure_pool_ready()
+    except Exception as db_error:
+        logging.error("Database not ready for warmup: %s", db_error)
+        await asyncio.sleep(30)
+        return
+
     logging.info("✅ Processing warmup accounts...")
 
     while True:
@@ -4964,17 +5046,16 @@ async def process_warmup_accounts():
 
         try:
             current_settings = await ensure_latest_warmup_settings()
-            now = datetime.now(timezone.utc)
-            is_warmup_join_time = is_warmup_join_period(now)
+            now_moscow = get_moscow_time()
+            is_warmup_join_time = is_warmup_join_period(now_moscow)
             daily_limit = current_settings.channels_per_day
 
-            if now.minute % 10 == 0:
-                message = (
-                    f"Warmup check: {now.strftime('%H:%M')} UTC, "
-                    f"is_warmup_join_time: {is_warmup_join_time}"
-                )
-                logging.debug(message)
-                add_summary("debug", message)
+            warmup_check_message = (
+                f"Warmup check: {now_moscow.strftime('%H:%M')} МСК, "
+                f"is_warmup_join_time: {is_warmup_join_time}"
+            )
+            logging.info(warmup_check_message)
+            add_summary("info", warmup_check_message)
 
             if not is_warmup_join_time:
                 await asyncio.sleep(WARMUP_SCAN_INTERVAL_SECONDS)
@@ -4998,7 +5079,7 @@ async def process_warmup_accounts():
                 try:
                     await process_single_warmup_account(
                         account,
-                        now=now,
+                        now=now_moscow,
                         current_settings=current_settings,
                         daily_limit=daily_limit,
                         add_summary=add_summary,
@@ -5941,6 +6022,10 @@ async def main():
             await ensure_latest_warmup_settings(force=True)
             logging.info("✅ Database initialized successfully")
             log_file.write("Database initialized successfully\n")
+            log_file.flush()
+
+            await auto_start_warmup_accounts()
+            log_file.write("Ensured warmup accounts are running\n")
             log_file.flush()
 
             deleted_logs = await cleanup_comment_logs(COMMENT_LOG_RETENTION_DAYS)


### PR DESCRIPTION
## Summary
- align the warmup_channels schema with the expected channel fields and add migrations so existing tables are corrected on startup
- refresh warmup channel synchronization and pending selection to populate channel usernames and expose an auto-start helper for warmup accounts
- invoke the auto-start helper during bot initialization so warmup accounts enter the running state automatically

## Testing
- pytest test_warmup_schedule.py *(fails: ImportError: cannot import name 'ChatWriteForbidden' from 'pyrogram.errors')*


------
https://chatgpt.com/codex/tasks/task_e_68f13ce93fe883308358daedcf87fe81