### PR TITLE
Ensure session lock creates directory before locking

### DIFF
--- a/main.py
+++ b/main.py
@@ -352,6 +352,10 @@ async def session_file_lock(session_path: str):
         yield
         return
 
+    directory = os.path.dirname(session_path)
+    if directory and not os.path.isdir(directory):
+        os.makedirs(directory, exist_ok=True)
+
     lock_path = session_path + ".lock"
     lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR)
 


### PR DESCRIPTION
## Summary
- create the session directory before taking the flock-based lock so first-time sessions don't fail

## Testing
- python -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68f224101ae883308fd4feaa352045d0