### PR TITLE
Handle cancellation in WarmupService run loop

### DIFF
--- a/services/warmup_service.py
+++ b/services/warmup_service.py
@@ -23,6 +23,9 @@ class WarmupService:
                 logging.info("💤 Цикл завершен, ждем 1 минуту (для теста)")
                 await asyncio.sleep(60)  # 1 минута для теста
 
+            except asyncio.CancelledError:
+                logging.info("🛑 Сервис прогрева отменен")
+                raise
             except Exception as e:
                 logging.error(f"❌ Ошибка в сервисе прогрева: {e}")
                 await asyncio.sleep(30)


### PR DESCRIPTION
## Summary
- allow asyncio.CancelledError to propagate when the warmup loop is cancelled
- log cancellation separately from generic errors so shutdown can complete cleanly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f23671a6108330b2e32c3601d9e230