### PR TITLE
Implement warmup account control methods

### DIFF
--- a/services/warmup_service.py
+++ b/services/warmup_service.py
@@ -8,6 +8,20 @@ class WarmupService:
         self.is_running = False
         self.accounts_stopped = False
 
+    async def stop_all_accounts(self):
+        """Временно останавливает все аккаунты (устанавливает флаг)"""
+        self.accounts_stopped = True
+        logging.info("🛑 Все аккаунты остановлены для прогрева")
+
+    async def start_all_accounts(self):
+        """Запускает аккаунты обратно"""
+        self.accounts_stopped = False
+        logging.info("🟢 Все аккаунты запущены после прогрева")
+
+    async def can_account_operate(self, account_id):
+        """Проверяет может ли аккаунт работать (не в режиме прогрева)"""
+        return not self.accounts_stopped
+
     async def run(self):
         """Основной цикл сервиса"""
         self.is_running = True


### PR DESCRIPTION
## Summary
- add methods to WarmupService to stop and start all accounts via a flag
- expose helper to check whether a specific account can operate based on the stop flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2399a4ce88330bc8756b0b98c2d4a