### PR TITLE
Use join_channel for warmup memberships

### DIFF
--- a/main.py
+++ b/main.py
@@ -4652,6 +4652,7 @@ async def join_channel(
     session_key: str,
     user_id: int,
     is_warmup: bool = False,
+    acquire_lock: bool = True,
 ) -> Tuple[bool, Optional[str]]:
     """Единая функция для вступления в канал (обычный или прогрев).
 
@@ -4764,6 +4765,7 @@ async def join_channel(
             session_name,
             _join_runner,
             lock_key=key,
+            acquire_lock=acquire_lock,
         )
 
     except TransientJoinError:

--- a/services/warmup_service.py
+++ b/services/warmup_service.py
@@ -14,8 +14,8 @@ class WarmupService:
             from db import (
                 get_running_warmup_accounts,
                 get_warmup_pending,
-                mark_warmup_channel_joined,
             )
+            from main import join_channel
 
             # 1. Получаем аккаунты для прогрева
             accounts = await get_running_warmup_accounts()
@@ -42,26 +42,42 @@ class WarmupService:
 
                     channel = pending_channels[0]
                     channel_name = channel.get("channel")
+
+                    if not channel_name:
+                        logging.warning(
+                            f"⚠️ Для аккаунта {phone} не указан канал для вступления"
+                        )
+                        continue
+
+                    session_key = account.get("phone")
+                    user_id = account.get("user_id")
+
+                    if not session_key or user_id is None:
+                        logging.warning(
+                            f"⚠️ Для аккаунта {phone} отсутствуют данные сессии для вступления в {channel_name}"
+                        )
+                        continue
+
                     logging.info(
                         f"📺 Аккаунт {phone} вступает в {channel_name}"
                     )
 
-                    # 3. Временная заглушка - всегда успешное вступление
-                    success = True
+                    success, error_message = await join_channel(
+                        channel=channel_name,
+                        account_id=account_id,
+                        session_key=session_key,
+                        user_id=user_id,
+                        is_warmup=True,
+                        acquire_lock=False,
+                    )
 
-                    if success and channel_name:
-                        # 4. Обновляем БД при успешном вступлении
-                        await mark_warmup_channel_joined(account_id, channel_name)
+                    if success:
                         logging.info(
                             f"✅ {phone} успешно вступил в {channel_name}"
                         )
-                    elif not channel_name:
-                        logging.warning(
-                            f"⚠️ Для аккаунта {phone} не указан канал для вступления"
-                        )
                     else:
                         logging.warning(
-                            f"⚠️ {phone} не смог вступить в {channel_name}"
+                            f"⚠️ {phone} не смог вступить в {channel_name}: {error_message}"
                         )
 
                 except Exception as e:

--- a/test_add_regular_channels.py
+++ b/test_add_regular_channels.py
@@ -56,7 +56,9 @@ def test_add_regular_channels_success_and_failure(monkeypatch):
         async def send_message(self, chat_id: int, text: str, **kwargs: Any) -> None:
             recorded_messages.append((chat_id, text))
 
-    async def fake_join_channel(channel, account_id, session_key, user_id, is_warmup=False):
+    async def fake_join_channel(
+        channel, account_id, session_key, user_id, is_warmup=False, acquire_lock=True
+    ):
         if channel == "@good":
             return True, None
         return False, "Ошибка доступа"


### PR DESCRIPTION
## Summary
- call the shared join_channel helper from the warmup service instead of a hardcoded success flag
- ensure warmup accounts validate session data before attempting to join channels and log failures with error details
- allow join_channel to skip lock acquisition when the caller already controls session state and update the related test doubles

## Testing
- pytest test_add_regular_channels.py

------
https://chatgpt.com/codex/tasks/task_e_68f246203c6c83308db152a6c1edee85