### PR TITLE
Integrate warmup UI controls and status command

### DIFF
--- a/db.py
+++ b/db.py
@@ -232,7 +232,7 @@ async def init_db() -> None:
     _POOL = await asyncpg.create_pool(dsn)
     _BACKEND = "postgres"
     await _init_postgres_schema()
-    await init_warmup_tables()
+    await ensure_warmup_tables()
 
 async def _init_postgres_schema() -> None:
     pool = _require_pool()
@@ -632,10 +632,6 @@ async def update_warmup_settings(
     await _execute(query, tuple(params))
 
 
-async def init_warmup_tables() -> None:
-    await ensure_warmup_tables()
-
-
 async def ensure_warmup_tables(connection: Optional[Any] = None) -> None:
     async def _ensure(conn: Any) -> None:
         await conn.execute(
@@ -869,7 +865,7 @@ def _convert_account_row(row: Any) -> Dict[str, Any]:
 
 async def get_all_accounts() -> List[Dict[str, Any]]:
     return await _fetch_accounts(
-        "SELECT * FROM accounts ORDER BY created_at",
+        "SELECT * FROM accounts ORDER BY id",
         (),
     )
 
@@ -1122,6 +1118,9 @@ async def update_last_reaction_at(
 
 
 async def set_account_mode(account_id: int, mode: str, warmup_days: Optional[int] = None) -> None:
+    if mode not in {"standard", "warmup"}:
+        raise ValueError("mode must be either 'standard' or 'warmup'")
+
     updates: List[str] = ["mode = ?"]
     params: List[Any] = [mode]
 
@@ -1140,7 +1139,14 @@ async def set_account_mode(account_id: int, mode: str, warmup_days: Optional[int
             ]
         )
     else:
-        updates.append("warmup_next_join_at = NULL")
+        updates.extend(
+            [
+                "warmup_joined_today = 0",
+                "warmup_last_join = NULL",
+                "warmup_last_join_at = NULL",
+                "warmup_next_join_at = NULL",
+            ]
+        )
 
     params.append(account_id)
 
@@ -1189,7 +1195,7 @@ async def get_warmup_channels(account_id: int) -> List[Dict[str, Any]]:
         SELECT *
         FROM warmup_channels
         WHERE account_id = ?
-        ORDER BY position
+        ORDER BY position, id
         """,
         (account_id,),
     )

--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ from db import (
     get_running_warmup_accounts,
     get_running_accounts,
     get_warmup_pending,
+    get_warmup_channels,
     get_warmup_settings,
     increment_warmup_joined,
     init_db,
@@ -2784,6 +2785,13 @@ async def main_message(message):
         if not is_running:
             builder.row(button_delete)
 
+    builder.row(
+        types.InlineKeyboardButton(
+            text="🔥 Прогрев аккаунта",
+            callback_data="warmup_settings",
+        )
+    )
+
     await bot.send_message(message.from_user.id, 'Ваши аккаунты', reply_markup=builder.as_markup())
     await bot.send_message(
         message.from_user.id,
@@ -2971,6 +2979,64 @@ async def test_warmup_command(message: Message) -> None:
     except Exception as e:
         await message.answer(f"❌ Ошибка: {e}")
         logging.exception("Error in test_warmup_command: %s", e)
+
+
+@dp.message(Command("warmup_status"))
+async def warmup_status_command(message: Message) -> None:
+    """Показывает актуальное состояние прогрева для всех аккаунтов пользователя."""
+
+    if not await is_user_authenticated(message.from_user.id):
+        await message.answer("Сначала авторизуйтесь командой /start")
+        return
+
+    accounts = await get_accounts_for_user(message.from_user.id)
+    if not accounts:
+        await message.answer("У вас нет добавленных аккаунтов.")
+        return
+
+    lines = ["🔥 Статус прогрева:"]
+    for account in accounts:
+        account_id = account.get("id")
+        phone = account.get("phone", "неизвестно")
+        if account_id is None:
+            lines.append(f"• {phone}: ⚠️ нет идентификатора аккаунта")
+            continue
+
+        warmup_records = await get_warmup_channels(account_id)
+        warmup_queue = [record.get("channel") for record in warmup_records if record.get("channel")]
+        has_queue = bool(warmup_queue)
+        is_warmup_mode = account.get("mode") == "warmup"
+
+        if has_queue and is_warmup_mode:
+            status_text = "✅ режим прогрева активен"
+        elif has_queue:
+            status_text = "⏳ каналы загружены, режим ожидания"
+        else:
+            status_text = "❌ прогрев отключен"
+
+        joined_today = account.get("warmup_joined_today") or 0
+        next_join_at = _parse_warmup_datetime(account.get("warmup_next_join_at"))
+        if next_join_at:
+            if next_join_at.tzinfo is None:
+                next_join_at = next_join_at.replace(tzinfo=timezone.utc)
+            else:
+                next_join_at = next_join_at.astimezone(timezone.utc)
+            next_join_display = next_join_at.strftime("%d.%m %H:%M UTC")
+        else:
+            next_join_display = "—"
+
+        lines.append(
+            "\n".join(
+                [
+                    f"• {phone}: {status_text}",
+                    f"  Каналов в прогреве: {len(warmup_queue)}",
+                    f"  Вступлений сегодня: {joined_today}",
+                    f"  Следующее вступление: {next_join_display}",
+                ]
+            )
+        )
+
+    await message.answer("\n".join(lines))
 
 
 @dp.message(Command("cleansessions"))

--- a/test_main_keyboard_layout.py
+++ b/test_main_keyboard_layout.py
@@ -92,7 +92,10 @@ async def test_main_menu_keyboard_layout_no_accounts(monkeypatch):
         "Первое сообщение должно содержать inline-клавиатуру с аккаунтами"
     )
     assert account_message["text"] == "Ваши аккаунты"
-    assert account_markup.inline_keyboard == [], "Без аккаунтов inline-клавиатура должна быть пустой"
+    keyboard_layout = [[button.text for button in row] for row in account_markup.inline_keyboard]
+    assert keyboard_layout == [["🔥 Прогрев аккаунта"]], "Ожидаем кнопку настроек прогрева"
+    warmup_callback = account_markup.inline_keyboard[0][0].callback_data
+    assert warmup_callback == "warmup_settings", "Кнопка прогрева должна вызывать warmup_settings"
 
     actions_markup = actions_message.get("markup")
     assert actions_message["text"] == "Доступные действия"


### PR DESCRIPTION
## Summary
- add a dedicated warmup settings button to the account inline menu and expose a /warmup_status command
- adjust warmup database helpers for postgres initialisation and ordering, and enforce valid modes
- update tests to cover the new warmup menu entry

## Testing
- pytest test_main_keyboard_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68f250a848748330a29e98d6ab7384c0