### PR TITLE
Add retry wrapper for joining channels

### DIFF
--- a/main.py
+++ b/main.py
@@ -4863,6 +4863,60 @@ async def send_comments(userid, session, account_id):
             _release_session_lock(key_inner)
 
 
+async def join_channel_with_retry(
+    channel: str,
+    account_id: int,
+    session_key: str,
+    user_id: int,
+    is_warmup: bool = False,
+    acquire_lock: bool = True,
+) -> Tuple[bool, Optional[str]]:
+    """Обертка вокруг :func:`join_channel` с повторными попытками при блокировках БД."""
+
+    max_retries = 3
+    delay = 2.0
+
+    for attempt in range(max_retries):
+        try:
+            success, error = await join_channel(
+                channel=channel,
+                account_id=account_id,
+                session_key=session_key,
+                user_id=user_id,
+                is_warmup=is_warmup,
+                acquire_lock=acquire_lock,
+            )
+
+            if success:
+                return True, None
+
+            if error and "locked" in error.lower() and attempt < max_retries - 1:
+                logging.warning(
+                    "🔒 Блокировка в join_channel, повтор %s/%s",
+                    attempt + 1,
+                    max_retries,
+                )
+                await asyncio.sleep(delay * (attempt + 1))
+                continue
+
+            return success, error
+
+        except Exception as exc:
+            error_text = str(exc)
+            if "locked" in error_text.lower() and attempt < max_retries - 1:
+                logging.warning(
+                    "🔒 Блокировка БД, повтор %s/%s",
+                    attempt + 1,
+                    max_retries,
+                )
+                await asyncio.sleep(delay * (attempt + 1))
+                continue
+
+            return False, error_text
+
+    return False, "Превышено количество попыток из-за блокировок БД"
+
+
 async def join_channel(
     channel: str,
     account_id: int,

--- a/services/warmup_service.py
+++ b/services/warmup_service.py
@@ -29,7 +29,7 @@ class WarmupService:
                 get_running_warmup_accounts,
                 get_warmup_pending,
             )
-            from main import join_channel
+            from main import join_channel_with_retry
 
             # 1. Получаем аккаунты для прогрева
             accounts = await get_running_warmup_accounts()
@@ -77,17 +77,13 @@ class WarmupService:
                     logging.info(f"📺 {phone} вступает в {channel_name}")
 
                     # ИСПОЛЬЗУЕМ ПОВТОРНЫЕ ПОПЫТКИ для вступления в канал
-                    success, error_message = await retry_on_lock(
-                        lambda: join_channel(
-                            channel=channel_name,
-                            account_id=account_id,
-                            session_key=session_key,
-                            user_id=user_id,
-                            is_warmup=True,
-                            acquire_lock=False,
-                        ),
-                        max_retries=2,
-                        delay=1.0
+                    success, error_message = await join_channel_with_retry(
+                        channel=channel_name,
+                        account_id=account_id,
+                        session_key=session_key,
+                        user_id=user_id,
+                        is_warmup=True,
+                        acquire_lock=False,
                     )
 
                     if success:


### PR DESCRIPTION
## Summary
- add a retry-enabled join_channel_with_retry helper around join_channel to handle database locks
- update the warmup service to call the new helper when joining warmup channels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f272c275988330aa4d6e070a21a142