### PR TITLE
Restore warmup session locking and session pragmas

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import logging
 import shutil
 import sqlite3
 import atexit
+import inspect
 from collections import Counter, defaultdict
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
@@ -504,7 +505,7 @@ async def safe_session_operation(
                 lock_acquired_at - wait_started_at,
             )
 
-        ensure_session_file_permissions(f"{session_path}.session")
+        await ensure_session_file_permissions(f"{session_path}.session")
         permissions_ready_at = loop.time()
         logging.debug(
             "safe_session_operation[%s]: session file prepared in %.2fs",
@@ -683,7 +684,7 @@ SKIP_LOG_EVENT_LABELS = {
 SKIP_SUMMARY_BUTTON_TEXT = "🕒 Сводка пропусков (лог-канал)"
 
 
-def ensure_session_file_permissions(session_file: str) -> None:
+async def ensure_session_file_permissions(session_file: str) -> None:
     """Ensure session file is writable with SQLite optimizations"""
 
     try:
@@ -706,17 +707,17 @@ def ensure_session_file_permissions(session_file: str) -> None:
                     "Не удалось изменить права доступа к файлу сессии: %s", session_file
                 )
 
-            try:
-                conn = sqlite3.connect(session_file, timeout=30.0)
-                conn.execute("PRAGMA journal_mode=WAL")
-                conn.execute("PRAGMA busy_timeout=30000")
-                conn.execute("PRAGMA synchronous=NORMAL")
-                conn.execute("PRAGMA cache_size=10000")
-                conn.close()
-            except Exception:
-                pass
+        import aiosqlite
+
+        async with aiosqlite.connect(session_file) as conn:
+            await conn.execute("PRAGMA journal_mode=WAL")
+            await conn.execute("PRAGMA busy_timeout=30000")
+            await conn.execute("PRAGMA synchronous=NORMAL")
+            await conn.execute("PRAGMA cache_size=-64000")
+            await conn.execute("PRAGMA foreign_keys=ON")
+            await conn.commit()
     except Exception:
-        logging.exception("Ошибка при настройке прав доступа для файла сессии: %s", session_file)
+        logging.warning("Не удалось настроить SQLite для %s", session_file)
 
 
 COMMENT_LOG_RETENTION_DAYS = 2
@@ -731,7 +732,7 @@ async def _run_with_sqlite_retries(
     *,
     attempts: int = 8,
     base_delay: float = 0.5,
-    on_retry: Optional[Callable[[int, BaseException], None]] = None,
+    on_retry: Optional[Callable[[int, BaseException], Union[None, Awaitable[None]]]] = None,
 ) -> Any:
     """Execute an async callable and retry when SQLite reports a locked database."""
 
@@ -747,7 +748,9 @@ async def _run_with_sqlite_retries(
                 last_exc = exc
                 if on_retry is not None:
                     try:
-                        on_retry(attempt, exc)
+                        maybe_awaitable = on_retry(attempt, exc)
+                        if inspect.isawaitable(maybe_awaitable):
+                            await maybe_awaitable
                     except Exception:  # pragma: no cover - defensive
                         logging.exception(
                             "Не удалось повторно подготовить сессию после ошибки блокировки"
@@ -768,9 +771,9 @@ async def _connect_client_with_retries(
     attempts: int = 8,
     base_delay: float = 0.5,
 ) -> None:
-    def _prepare_session(_: int, __: BaseException) -> None:
+    async def _prepare_session(_: int, __: BaseException) -> None:
         if session_file:
-            ensure_session_file_permissions(session_file)
+            await ensure_session_file_permissions(session_file)
 
     await _run_with_sqlite_retries(
         client.connect,
@@ -787,9 +790,9 @@ async def _start_client_with_retries(
     attempts: int = 8,
     base_delay: float = 0.5,
 ) -> None:
-    def _prepare_session(_: int, __: BaseException) -> None:
+    async def _prepare_session(_: int, __: BaseException) -> None:
         if session_file:
-            ensure_session_file_permissions(session_file)
+            await ensure_session_file_permissions(session_file)
 
     await _run_with_sqlite_retries(
         client.start,
@@ -806,9 +809,9 @@ async def _stop_client_with_retries(
     attempts: int = 5,
     base_delay: float = 0.5,
 ) -> None:
-    def _prepare_session(_: int, __: BaseException) -> None:
+    async def _prepare_session(_: int, __: BaseException) -> None:
         if session_file:
-            ensure_session_file_permissions(session_file)
+            await ensure_session_file_permissions(session_file)
 
     await _run_with_sqlite_retries(
         client.stop,
@@ -865,9 +868,9 @@ async def _disconnect_client_with_retries(
     attempts: int = 5,
     base_delay: float = 0.5,
 ) -> None:
-    def _prepare_session(_: int, __: BaseException) -> None:
+    async def _prepare_session(_: int, __: BaseException) -> None:
         if session_file:
-            ensure_session_file_permissions(session_file)
+            await ensure_session_file_permissions(session_file)
 
     await _run_with_sqlite_retries(
         client.disconnect,
@@ -1642,7 +1645,7 @@ async def process_account_reactions(account: Dict[str, Any]) -> None:
         )
         return
 
-    ensure_session_file_permissions(session_path)
+    await ensure_session_file_permissions(session_path)
 
     if session_path.endswith(".session"):
         session_name = session_path[:-len(".session")]
@@ -1747,7 +1750,7 @@ async def process_account_comments(account: Dict[str, Any]) -> None:
             )
         return
 
-    ensure_session_file_permissions(session_path)
+    await ensure_session_file_permissions(session_path)
 
     active_sessions[key] = True
     active_account_ids[key] = account_id
@@ -4874,7 +4877,8 @@ async def join_channel_with_retry(
     """Обертка вокруг :func:`join_channel` с повторными попытками при блокировках БД."""
 
     max_retries = 3
-    delay = 2.0
+    delay = 3.0
+    lock_keywords = ("locked", "blocked", "busy", "timeout")
 
     for attempt in range(max_retries):
         try:
@@ -4890,7 +4894,7 @@ async def join_channel_with_retry(
             if success:
                 return True, None
 
-            if error and "locked" in error.lower() and attempt < max_retries - 1:
+            if error and any(word in error.lower() for word in lock_keywords) and attempt < max_retries - 1:
                 logging.warning(
                     "🔒 Блокировка в join_channel, повтор %s/%s",
                     attempt + 1,
@@ -4903,7 +4907,7 @@ async def join_channel_with_retry(
 
         except Exception as exc:
             error_text = str(exc)
-            if "locked" in error_text.lower() and attempt < max_retries - 1:
+            if any(word in error_text.lower() for word in lock_keywords) and attempt < max_retries - 1:
                 logging.warning(
                     "🔒 Блокировка БД, повтор %s/%s",
                     attempt + 1,
@@ -4947,13 +4951,13 @@ async def join_channel(
                     )
                     await bot.send_message(log_channel, error_message)
                     return False, error_message
-                ensure_session_file_permissions(session_file)
+                await ensure_session_file_permissions(session_file)
             else:
                 error_message = f"Аккаунт {session_key} - файл сессии не найден: {session_file}"
                 await bot.send_message(log_channel, error_message)
                 return False, error_message
         else:
-            ensure_session_file_permissions(session_file)
+            await ensure_session_file_permissions(session_file)
 
         key = make_session_key(user_id, session_key)
 
@@ -6077,7 +6081,7 @@ async def get_account_summary(account_id):
     try:
         session_path = account.get('session_path', '')
         if session_path and os.path.exists(session_path):
-            ensure_session_file_permissions(session_path)
+            await ensure_session_file_permissions(session_path)
 
             user_id_value = account.get("user_id")
             phone_value = account.get("phone")

--- a/services/warmup_service.py
+++ b/services/warmup_service.py
@@ -9,7 +9,8 @@ async def retry_on_lock(operation, max_retries=3, delay=1.0):
         try:
             return await operation()
         except Exception as e:
-            if "locked" in str(e).lower() and attempt < max_retries - 1:
+            message = str(e).lower()
+            if any(word in message for word in ["locked", "blocked", "busy", "timeout"]) and attempt < max_retries - 1:
                 logging.warning(f"🔒 Блокировка БД, повтор {attempt + 1}/{max_retries}")
                 await asyncio.sleep(delay * (attempt + 1))
             else:
@@ -40,7 +41,7 @@ class WarmupService:
                 try:
                     # ПАУЗА между аккаунтами для снижения нагрузки на БД
                     if i > 0:
-                        await asyncio.sleep(2)  # 2 секунды между аккаунтами
+                        await asyncio.sleep(5)  # 5 секунд между аккаунтами
 
                     account_id = account.get("id")
                     phone = account.get("phone", "unknown")
@@ -83,7 +84,7 @@ class WarmupService:
                         session_key=session_key,
                         user_id=user_id,
                         is_warmup=True,
-                        acquire_lock=False,
+                        acquire_lock=True,
                     )
 
                     if success:
@@ -93,6 +94,7 @@ class WarmupService:
 
                 except Exception as e:
                     logging.error(f"❌ Ошибка прогрева {account.get('phone', 'unknown')}: {e}")
+                    await asyncio.sleep(3)
 
         except Exception as e:
             logging.error(f"💥 Критическая ошибка в цикле прогрева: {e}")


### PR DESCRIPTION
## Summary
- reinstate warmup channel joins with session locks and larger spacing between accounts
- harden database retry handling and lock detection during warmup joins
- convert session preparation to async SQLite setup with WAL/busy-timeout pragmas and await it everywhere

## Testing
- python -m compileall main.py services/warmup_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f275d653048330aa264e97337377c2