### PR TITLE
Fix reaction log to use channel message id

### DIFF
--- a/reaction_engine.py
+++ b/reaction_engine.py
@@ -767,7 +767,7 @@ class ReactionEngine:
                 await self._log_reaction_event(
                     account_id,
                     channel_id,
-                    message_id,
+                    channel_message_id,
                     emoji,
                     success=True,
                     error_message=None,
@@ -795,7 +795,7 @@ class ReactionEngine:
                 await self._log_reaction_event(
                     account_id,
                     channel_id,
-                    message_id,
+                    channel_message_id,
                     emoji,
                     success=False,
                     error_message=str(exc),


### PR DESCRIPTION
## Summary
- ensure reaction logging uses the originating channel message id so counts stay aligned with existing consumers

## Testing
- python -m compileall reaction_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68f8b0e91888833088988313e31de338