### PR TITLE
Handle regular discussion reply messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -895,12 +895,37 @@ _CORRUPTED_SESSION_ERRORS = (
 )
 
 
-def _is_discussion_reply_message(message: Any) -> bool:
+def _is_regular_reply_message(message: Any) -> bool:
+    """Определить обычные reply-сообщения (ответы на комментарии)."""
+
     reply = getattr(message, "reply_to_message", None)
     if not reply:
         return False
+
     forward_chat = getattr(reply, "forward_from_chat", None)
-    return forward_chat is not None
+    if forward_chat is not None:
+        return False
+
+    chat = getattr(message, "chat", None)
+    if not chat:
+        return False
+
+    chat_type = getattr(chat, "type", None)
+    return chat_type in ["group", "supergroup"]
+
+
+def _is_discussion_reply_message(message: Any) -> bool:
+    """Определить сообщения в обсуждениях (пересланные из каналов или обычные reply)."""
+
+    reply = getattr(message, "reply_to_message", None)
+    if not reply:
+        return False
+
+    forward_chat = getattr(reply, "forward_from_chat", None)
+    if forward_chat is not None:
+        return True
+
+    return _is_regular_reply_message(message)
 
 
 def _is_self_generated_message(message: Any) -> bool:


### PR DESCRIPTION
## Summary
- add a helper that detects regular reply messages in group discussions
- expand the discussion reply detector to also recognize non-forwarded replies while preserving the existing forwarded message handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8d99fd3a8833090746aae812516b2