### PR TITLE
Restore direct discussion reply overrides

### DIFF
--- a/main.py
+++ b/main.py
@@ -1971,7 +1971,7 @@ async def _handle_linked_channel_message(
         selected_reaction_chance_value = (
             selected_reaction_chance_override
             if selected_reaction_chance_override is not None
-            else (reaction_discussion_chance or 0)
+            else reaction_discussion_chance
         )
 
         if comment_prompt_value is None or comment_chance_value is None:
@@ -1979,6 +1979,7 @@ async def _handle_linked_channel_message(
                 "Обсуждения отключены для %s: отсутствуют настройки", session
             )
             return current_last_reaction_at
+
         comment_chance = comment_chance_value
         comment_prompt = comment_prompt_value
         selected_reaction_chance = selected_reaction_chance_value


### PR DESCRIPTION
## Summary
- ensure discussion reply handling uses the discussion-specific chance, prompt, and reaction probability instead of falling back to post-level defaults
- keep the first-level post handling unchanged

## Testing
- pytest test_linked_discussion_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68f9daf098588330a4220ebc39a5b02d