### PR TITLE
Log reply reactions immediately

### DIFF
--- a/main.py
+++ b/main.py
@@ -1234,7 +1234,6 @@ async def _maybe_send_reaction(
     last_reaction_error: Optional[BaseException] = None
     last_reaction_error_text: Optional[str] = None
     attempts_performed = 0
-
     for reaction_attempt in range(1, max_reaction_attempts + 1):
         if not working_reaction_emojis:
             break
@@ -1284,13 +1283,19 @@ async def _maybe_send_reaction(
             ):
                 reaction_link = f"{reaction_link}?comment={message.id}"
 
-            await bot.send_message(
-                log_channel,
-                (
+            if log_channel:
+                reaction_link_text = reaction_link or ""
+                link_suffix = f"\n{reaction_link_text}" if reaction_link_text else ""
+                log_text = (
                     f'Аккаунт {session} поставил реакцию {reaction_emoji}'
-                    f'{reaction_comment_context}\n{reaction_link}'
-                ),
-            )
+                    f'{reaction_comment_context}{link_suffix}'
+                )
+                try:
+                    await bot.send_message(log_channel, log_text)
+                except Exception:
+                    logging.exception(
+                        "Не удалось отправить лог реакции для аккаунта %s", session
+                    )
             await update_last_reaction_at_with_logging(account_id, now)
             current_last_reaction_at = now
             await asyncio.sleep(0.2)

--- a/test_linked_discussion_handler.py
+++ b/test_linked_discussion_handler.py
@@ -1211,6 +1211,7 @@ async def test_reaction_sent_for_reply_to_own_comment(monkeypatch):
 
     comment_logs = []
     updated_reactions: list[tuple[int, datetime]] = []
+    bot_logs: list[tuple[int, str]] = []
 
     async def fake_add_comment_log(*args, **kwargs):
         comment_logs.append((args, kwargs))
@@ -1224,7 +1225,8 @@ async def test_reaction_sent_for_reply_to_own_comment(monkeypatch):
     async def fake_update_last_reaction_at(account, ts):
         updated_reactions.append((account, ts))
 
-    async def fake_bot_send_message(*args, **kwargs):
+    async def fake_bot_send_message(chat_id, text, **kwargs):
+        bot_logs.append((chat_id, text))
         return None
 
     monkeypatch.setattr(main, "REACTION_MIN_INTERVAL_SECONDS", 60)
@@ -1276,6 +1278,10 @@ async def test_reaction_sent_for_reply_to_own_comment(monkeypatch):
     assert updated_reactions[-1][0] == account_id
     assert updated_reactions[-1][1] == result
     assert result >= recent_reaction
+    assert any(
+        "поставил реакцию 🔥" in text and "ответ на комментарий аккаунта" in text
+        for _, text in bot_logs
+    )
 
 
 @pytest.mark.anyio
@@ -1308,6 +1314,7 @@ async def test_reaction_for_reply_detected_via_comment_log(monkeypatch):
 
     comment_logs = []
     updated_reactions: list[tuple[int, datetime]] = []
+    bot_logs: list[tuple[int, str]] = []
 
     async def fake_add_comment_log(*args, **kwargs):
         comment_logs.append((args, kwargs))
@@ -1321,7 +1328,8 @@ async def test_reaction_for_reply_detected_via_comment_log(monkeypatch):
     async def fake_update_last_reaction_at(account, ts):
         updated_reactions.append((account, ts))
 
-    async def fake_bot_send_message(*args, **kwargs):
+    async def fake_bot_send_message(chat_id, text, **kwargs):
+        bot_logs.append((chat_id, text))
         return None
 
     async def fake_has_successful_comment(account, channel, message_id):
@@ -1380,6 +1388,10 @@ async def test_reaction_for_reply_detected_via_comment_log(monkeypatch):
     assert updated_reactions[-1][0] == account_id
     assert updated_reactions[-1][1] == result
     assert result >= recent_reaction
+    assert any(
+        "поставил реакцию 🔥" in text and "ответ на комментарий аккаунта" in text
+        for _, text in bot_logs
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- emit the log entry right after sending a reaction so reply reactions always reach the bot log channel
- extend the reply-reaction tests to assert the expected log message is produced for both direct and log-detected replies

## Testing
- pytest test_linked_discussion_handler.py::test_reaction_sent_for_reply_to_own_comment -q
- pytest test_linked_discussion_handler.py::test_reaction_for_reply_detected_via_comment_log -q

------
https://chatgpt.com/codex/tasks/task_e_68fa04eca2d883308e592fd819581edc